### PR TITLE
Harden GitHub URL/auth handling and prevent token leakage

### DIFF
--- a/R/github-helpers.R
+++ b/R/github-helpers.R
@@ -8,7 +8,7 @@
 #'
 #' @param path Character scalar path inside the repository (e.g.,
 #'   `"data/myfile.csv"`), or a full GitHub URL (blob or raw) which will be
-#'   normalized.
+#'   normalized. Non-GitHub URLs are rejected.
 #' @param ref Git reference: branch name, tag, or commit SHA. Defaults to
 #'   `"main"`. For reproducible analyses, prefer tags or commit SHAs over
 #'   branch names.
@@ -155,9 +155,9 @@ ms_setup_github <- function(repo = "dfo-pacific-science/qualark-data") {
 #' @return A tibble containing the CSV data.
 #'
 #' @details
-#' Before using this function, run `ms_setup_github()` once to configure
-#' authentication. For private repositories, your PAT must have the `repo`
-#' scope.
+#' Public GitHub content can be read without a PAT. For private repositories,
+#' run `ms_setup_github()` to configure authentication; your PAT must have the
+#' `repo` scope.
 #'
 #' For reproducible analyses, pin to a specific tag or commit SHA rather than
 #' a branch name like `"main"`, since branch contents can change over time.
@@ -210,20 +210,13 @@ read_github_csv <- function(
 ) {
   target <- ms_resolve_path(path, ref = ref, repo = repo)
   token <- if (is.null(token)) ms_current_token() else token
-
-  if (!nzchar(token)) {
-    cli::cli_abort("No GitHub PAT found. Run {.code metasalmon::ms_setup_github()} first.")
-  }
-
-  resp <- httr2::request(target$url) |>
-    httr2::req_headers(Authorization = paste("token", token)) |>
-    httr2::req_user_agent(ms_user_agent()) |>
-    httr2::req_retry(backoff = ~2^.x, max_tries = 4) |>
-    httr2::req_perform()
+  resp <- ms_github_get(target$url, token = token)
 
   status <- httr2::resp_status(resp)
   if (status == 401) {
-    cli::cli_abort("GitHub authentication failed. Run {.code metasalmon::ms_setup_github()} to refresh your PAT.")
+    cli::cli_abort(
+      "GitHub authentication failed. Run {.code metasalmon::ms_setup_github()} to refresh your PAT."
+    )
   }
 
   if (status == 403) {
@@ -233,10 +226,20 @@ read_github_csv <- function(
         "Access blocked by org SSO. Re-authorize your PAT for this org at {.url https://github.com/settings/tokens}."
       )
     }
-    cli::cli_abort("Access to {.val {target$repo}} was denied (status 403).")
+    if (nzchar(token)) {
+      cli::cli_abort("Access to {.val {target$repo}} was denied (status 403).")
+    }
+    cli::cli_abort(
+      "Access to {.val {target$repo}} was denied without authentication (status 403). Add a PAT with {.code metasalmon::ms_setup_github()} and retry."
+    )
   }
 
   if (status == 404) {
+    if (!nzchar(token)) {
+      cli::cli_abort(
+        "Path {.path {target$path}} not found at ref {.val {target$ref}} in {.val {target$repo}}. If this repository is private, configure a PAT with {.code metasalmon::ms_setup_github()} and retry."
+      )
+    }
     cli::cli_abort(
       "Path {.path {target$path}} not found at ref {.val {target$ref}} in {.val {target$repo}}."
     )
@@ -273,12 +276,12 @@ read_github_csv <- function(
 #'
 #' @details
 #' This function uses the GitHub API to list directory contents, filters for CSV
-#' files, then reads each file using `read_github_csv()`. Authentication is
-#' required even for public repositories when using the API.
+#' files, then reads each file using `read_github_csv()`. For public
+#' repositories, directory listing can work without a PAT; when available, a
+#' token is used automatically.
 #'
-#' Before using this function, run `ms_setup_github()` once to configure
-#' authentication. For private repositories, your PAT must have the `repo`
-#' scope.
+#' For private repositories, run `ms_setup_github()` to configure
+#' authentication. Your PAT must have the `repo` scope.
 #'
 #' For reproducible analyses, pin to a specific tag or commit SHA rather than
 #' a branch name like `"main"`, since branch contents can change over time.
@@ -335,20 +338,14 @@ read_github_csv_dir <- function(
 ) {
   target <- ms_resolve_dir_path(path, ref = ref, repo = repo)
   token <- if (is.null(token)) ms_current_token() else token
-
-  if (!nzchar(token)) {
-    cli::cli_abort("No GitHub PAT found. Run {.code metasalmon::ms_setup_github()} first.")
-  }
-
-  # List directory contents using GitHub API
-  if (target$path == "") {
-    api_path <- sprintf("/repos/%s/contents", target$repo)
-  } else {
-    api_path <- sprintf("/repos/%s/contents/%s", target$repo, target$path)
-  }
   tryCatch(
     {
-      contents <- gh::gh(api_path, .token = token, ref = target$ref)
+      contents <- ms_github_list_contents(
+        repo = target$repo,
+        path = target$path,
+        ref = target$ref,
+        token = token
+      )
     },
     error = function(e) {
       if (grepl("404", conditionMessage(e))) {
@@ -356,8 +353,27 @@ read_github_csv_dir <- function(
           "Directory {.path {target$path}} not found at ref {.val {target$ref}} in {.val {target$repo}}."
         )
       }
-      if (grepl("401|403", conditionMessage(e))) {
-        cli::cli_abort("GitHub authentication failed. Run {.code metasalmon::ms_setup_github()} to refresh your PAT.")
+      headers <- tryCatch(e$response$headers, error = function(...) list())
+      sso <- headers[["x-github-sso"]]
+      if (!is.null(sso)) {
+        cli::cli_abort(
+          "Access blocked by org SSO. Re-authorize your PAT for this org at {.url https://github.com/settings/tokens}."
+        )
+      }
+      if (grepl("401", conditionMessage(e))) {
+        cli::cli_abort(
+          "GitHub authentication failed. Run {.code metasalmon::ms_setup_github()} to refresh your PAT."
+        )
+      }
+      if (grepl("403", conditionMessage(e))) {
+        if (nzchar(token)) {
+          cli::cli_abort(
+            "Access to {.val {target$repo}} was denied (status 403)."
+          )
+        }
+        cli::cli_abort(
+          "Anonymous access to {.val {target$repo}} was denied (status 403). Add a PAT with {.code metasalmon::ms_setup_github()} and retry."
+        )
       }
       cli::cli_abort("Unable to list directory contents: {conditionMessage(e)}")
     }
@@ -437,9 +453,17 @@ ms_resolve_dir_path <- function(path, ref, repo) {
 
   if (grepl("^https?://", path)) {
     clean_url <- sub("\\?.*$", "", path)
+    if (!ms_is_github_host(clean_url)) {
+      cli::cli_abort(
+        "URL inputs must use {.url github.com} (tree/blob) or {.url raw.githubusercontent.com}."
+      )
+    }
 
     # Handle blob URLs (directory)
-    blob_match <- regexec("^https?://github\\.com/([^/]+)/([^/]+)/(?:blob|tree)/([^/]+)/(.*)$", clean_url)
+    blob_match <- regexec(
+      "^https?://(?:www\\.)?github\\.com/([^/]+)/([^/]+)/(?:blob|tree)/([^/]+)/(.*)$",
+      clean_url
+    )
     blob_parts <- regmatches(clean_url, blob_match)[[1]]
     if (length(blob_parts) == 5) {
       return(list(
@@ -462,7 +486,9 @@ ms_resolve_dir_path <- function(path, ref, repo) {
       ))
     }
 
-    cli::cli_abort("Unable to parse GitHub URL: {.val {path}}")
+    cli::cli_abort(
+      "Unable to parse GitHub URL: {.val {path}}. Use a github.com tree/blob URL or raw.githubusercontent.com URL."
+    )
   }
 
   if (is.null(clean_repo)) {
@@ -505,8 +531,13 @@ ms_resolve_path <- function(path, ref, repo) {
 
   if (grepl("^https?://", path)) {
     clean_url <- sub("\\?.*$", "", path)
+    if (!ms_is_github_host(clean_url)) {
+      cli::cli_abort(
+        "URL inputs must use {.url github.com} (blob) or {.url raw.githubusercontent.com}."
+      )
+    }
 
-    blob_match <- regexec("^https?://github\\.com/([^/]+)/([^/]+)/blob/([^/]+)/(.+)$", clean_url)
+    blob_match <- regexec("^https?://(?:www\\.)?github\\.com/([^/]+)/([^/]+)/blob/([^/]+)/(.+)$", clean_url)
     blob_parts <- regmatches(clean_url, blob_match)[[1]]
     if (length(blob_parts) == 5) {
       return(list(
@@ -534,7 +565,9 @@ ms_resolve_path <- function(path, ref, repo) {
       ))
     }
 
-    return(list(url = clean_url, repo = clean_repo %||% "", ref = clean_ref, path = path))
+    cli::cli_abort(
+      "Unable to parse GitHub URL: {.val {path}}. Use a github.com blob URL or raw.githubusercontent.com URL."
+    )
   }
 
   if (is.null(clean_repo)) {
@@ -548,6 +581,41 @@ ms_resolve_path <- function(path, ref, repo) {
     ref = clean_ref,
     path = clean_path
   )
+}
+
+ms_is_github_host <- function(url) {
+  parsed <- httr2::url_parse(url)
+  host <- tolower(parsed$hostname %||% "")
+  host %in% c("github.com", "www.github.com", "raw.githubusercontent.com")
+}
+
+ms_github_get <- function(url, token = NULL) {
+  req <- httr2::request(url) |>
+    httr2::req_user_agent(ms_user_agent()) |>
+    httr2::req_retry(backoff = ~2^.x, max_tries = 4)
+
+  if (is.null(token)) {
+    token <- ""
+  }
+  if (nzchar(token) && ms_is_github_host(url)) {
+    req <- httr2::req_headers(req, Authorization = paste("token", token))
+  }
+
+  httr2::req_perform(req)
+}
+
+ms_github_list_contents <- function(repo, path, ref, token = NULL) {
+  if (path == "") {
+    api_path <- sprintf("/repos/%s/contents", repo)
+  } else {
+    api_path <- sprintf("/repos/%s/contents/%s", repo, path)
+  }
+
+  if (is.null(token) || !nzchar(token)) {
+    gh::gh(api_path, ref = ref)
+  } else {
+    gh::gh(api_path, .token = token, ref = ref)
+  }
 }
 
 ms_user_agent <- function() {

--- a/man/github_raw_url.Rd
+++ b/man/github_raw_url.Rd
@@ -9,7 +9,7 @@ github_raw_url(path, ref = "main", repo = NULL)
 \arguments{
 \item{path}{Character scalar path inside the repository (e.g.,
 \code{"data/myfile.csv"}), or a full GitHub URL (blob or raw) which will be
-normalized.}
+normalized. Non-GitHub URLs are rejected.}
 
 \item{ref}{Git reference: branch name, tag, or commit SHA. Defaults to
 \code{"main"}. For reproducible analyses, prefer tags or commit SHAs over

--- a/man/read_github_csv.Rd
+++ b/man/read_github_csv.Rd
@@ -8,7 +8,8 @@ read_github_csv(path, ref = "main", repo = NULL, token = NULL, ...)
 }
 \arguments{
 \item{path}{Path to the CSV file inside the repository (e.g.,
-\code{"data/observations.csv"}), or a full GitHub URL (blob or raw format).}
+\code{"data/observations.csv"}), or a full GitHub URL (blob or raw format).
+Non-GitHub URLs are rejected.}
 
 \item{ref}{Git reference: branch name, tag, or commit SHA. Defaults to
 \code{"main"}. For reproducible analyses, prefer tags or commit SHAs.
@@ -36,9 +37,9 @@ the URL.
 This function supports automatic retries with exponential backoff for
 transient network errors.
 
-Before using this function, run \code{ms_setup_github()} once to configure
-authentication. For private repositories, your PAT must have the \code{repo}
-scope.
+Public GitHub content can be read without a PAT. For private repositories,
+run \code{ms_setup_github()} to configure authentication; your PAT must have the
+\code{repo} scope.
 
 For reproducible analyses, pin to a specific tag or commit SHA rather than
 a branch name like \code{"main"}, since branch contents can change over time.

--- a/man/read_github_csv_dir.Rd
+++ b/man/read_github_csv_dir.Rd
@@ -46,12 +46,12 @@ multiple local CSV files.
 }
 \details{
 This function uses the GitHub API to list directory contents, filters for CSV
-files, then reads each file using \code{read_github_csv()}. Authentication is
-required even for public repositories when using the API.
+files, then reads each file using \code{read_github_csv()}. For public
+repositories, directory listing can work without a PAT; when available, a
+token is used automatically.
 
-Before using this function, run \code{ms_setup_github()} once to configure
-authentication. For private repositories, your PAT must have the \code{repo}
-scope.
+For private repositories, run \code{ms_setup_github()} to configure
+authentication. Your PAT must have the \code{repo} scope.
 
 For reproducible analyses, pin to a specific tag or commit SHA rather than
 a branch name like \code{"main"}, since branch contents can change over time.

--- a/tests/testthat/test-github-helpers.R
+++ b/tests/testthat/test-github-helpers.R
@@ -38,14 +38,96 @@ test_that("GitHub path resolution handles blob and raw URLs", {
   expect_equal(raw$path, "path/to/file.csv")
 })
 
-test_that("read_github_csv errors early without a token", {
+test_that("GitHub helper URL parsing rejects non-GitHub remote URLs", {
   expect_error(
-    read_github_csv("data/gold/dimension_tables/dim_date.csv", repo = "owner/repo", token = ""),
-    "No GitHub PAT found"
+    metasalmon:::ms_resolve_path(
+      "https://example.com/data.csv",
+      ref = "main",
+      repo = NULL
+    ),
+    "URL inputs must use"
+  )
+
+  expect_error(
+    metasalmon:::ms_resolve_dir_path(
+      "https://example.com/data",
+      ref = "main",
+      repo = NULL
+    ),
+    "URL inputs must use"
   )
 })
 
-test_that("read_github_csv can fetch when a token is configured", {
+test_that("read_github_csv rejects non-GitHub URLs before any fetch", {
+  expect_error(
+    with_mocked_bindings(
+      ms_github_get = function(url, token = NULL) {
+        stop("network call should not happen")
+      },
+      read_github_csv("https://example.com/data.csv", token = "secret"),
+      .package = "metasalmon"
+    ),
+    "URL inputs must use"
+  )
+})
+
+test_that("read_github_csv can read public content without a token", {
+  out <- with_mocked_bindings(
+    ms_resolve_path = function(path, ref, repo) {
+      list(
+        url = "https://raw.githubusercontent.com/owner/repo/main/path/to/file.csv",
+        repo = "owner/repo",
+        ref = "main",
+        path = "path/to/file.csv"
+      )
+    },
+    ms_current_token = function() "",
+    ms_github_get = function(url, token = NULL) {
+      expect_equal(token, "")
+      httr2::response(
+        status_code = 200,
+        url = url,
+        body = charToRaw("a,b\n1,2\n")
+      )
+    },
+    read_github_csv("path/to/file.csv", repo = "owner/repo"),
+    .package = "metasalmon"
+  )
+
+  expect_s3_class(out, "data.frame")
+  expect_equal(nrow(out), 1)
+  expect_equal(ncol(out), 2)
+})
+
+test_that("read_github_csv_dir can list and read public content without a token", {
+  used_tokens <- character()
+  out <- with_mocked_bindings(
+    ms_resolve_dir_path = function(path, ref, repo) {
+      list(repo = "owner/repo", ref = "main", path = "data")
+    },
+    ms_current_token = function() "",
+    ms_github_list_contents = function(repo, path, ref, token = NULL) {
+      expect_equal(token, "")
+      list(
+        list(type = "file", name = "a.csv"),
+        list(type = "file", name = "b.txt"),
+        list(type = "file", name = "c.csv")
+      )
+    },
+    read_github_csv = function(path, ref = "main", repo = NULL, token = NULL, ...) {
+      used_tokens <<- c(used_tokens, token)
+      data.frame(x = 1, stringsAsFactors = FALSE)
+    },
+    read_github_csv_dir("data", repo = "owner/repo"),
+    .package = "metasalmon"
+  )
+
+  expect_type(out, "list")
+  expect_equal(names(out), c("a", "c"))
+  expect_equal(used_tokens, c("", ""))
+})
+
+test_that("read_github_csv can read remote content with a token", {
   token <- metasalmon:::ms_current_token()
   skip_if(!nzchar(token), "No GitHub token configured; skipping Qualark fetch test.")
 
@@ -78,11 +160,18 @@ test_that("read_github_csv can fetch when a token is configured", {
   expect_gt(ncol(df), 0)
 })
 
-test_that("read_github_csv_dir errors early without a token", {
-  expect_error(
-    read_github_csv_dir("data/observations", repo = "owner/repo", token = ""),
-    "No GitHub PAT found"
+test_that("read_github_csv without token can read a known public GitHub raw CSV", {
+  skip_if_offline()
+
+  df <- read_github_csv(
+    "https://raw.githubusercontent.com/dfo-pacific-science/metasalmon/main/inst/extdata/nuseds-fraser-coho-sample.csv",
+    token = "",
+    progress = FALSE
   )
+
+  expect_s3_class(df, "data.frame")
+  expect_gt(nrow(df), 0)
+  expect_gt(ncol(df), 0)
 })
 
 test_that("ms_resolve_dir_path handles directory paths correctly", {
@@ -129,7 +218,6 @@ test_that("read_github_csv_dir can fetch when a token is configured", {
   dir_path <- Sys.getenv("METASALMON_QUALARK_TEST_DIR", "data/gold/dimension_tables")
   ref <- Sys.getenv("METASALMON_QUALARK_TEST_REF", "main")
 
-  # Verify we can access the repo
   tryCatch(
     gh::gh(sprintf("/repos/%s", repo), .token = token),
     error = function(e) {
@@ -137,7 +225,6 @@ test_that("read_github_csv_dir can fetch when a token is configured", {
     }
   )
 
-  # Verify the directory exists and has contents
   tryCatch(
     {
       contents <- gh::gh(
@@ -145,11 +232,9 @@ test_that("read_github_csv_dir can fetch when a token is configured", {
         .token = token,
         ref = ref
       )
-      # Check if it's actually a directory (array) or a single file
       if (!is.null(contents$type) && contents$type == "file") {
         testthat::skip(paste("Path", dir_path, "is a file, not a directory"))
       }
-      # Check if directory has any CSV files
       csv_files <- Filter(
         function(x) x$type == "file" && grepl("\\.csv$", x$name, ignore.case = TRUE),
         contents
@@ -163,18 +248,13 @@ test_that("read_github_csv_dir can fetch when a token is configured", {
     }
   )
 
-  # Test reading the directory
   data_list <- read_github_csv_dir(dir_path, ref = ref, repo = repo, token = token)
 
   expect_type(data_list, "list")
   expect_gt(length(data_list), 0)
-
-  # Check that all elements are data frames
   for (i in seq_along(data_list)) {
     expect_s3_class(data_list[[i]], "data.frame")
   }
-
-  # Check that names are set (file names without .csv extension)
   expect_true(all(nchar(names(data_list)) > 0))
 })
 
@@ -185,31 +265,14 @@ test_that("read_github_csv_dir handles empty directories", {
   repo <- Sys.getenv("METASALMON_QUALARK_TEST_REPO", "dfo-pacific-science/qualark-data")
   ref <- Sys.getenv("METASALMON_QUALARK_TEST_REF", "main")
 
-  # Try to find an empty directory or create a test scenario
-  # For now, we'll test that it returns an empty list gracefully
-  # This test might skip if we can't find an appropriate test directory
-  tryCatch(
-    {
-      # Try root directory - might have files, but we can test the pattern matching
-      result <- read_github_csv_dir(
-        "nonexistent-directory-that-should-not-exist",
-        ref = ref,
-        repo = repo,
-        token = token,
-        pattern = "definitely_no_files_match_this_pattern_12345\\.csv$"
-      )
-      expect_type(result, "list")
-      expect_equal(length(result), 0)
-    },
-    error = function(e) {
-      # If directory doesn't exist, we get an error, which is expected
-      if (grepl("not found|404", conditionMessage(e), ignore.case = TRUE)) {
-        # This is expected behavior
-        expect_true(TRUE)
-      } else {
-        # Other errors should still be tested
-        testthat::skip(paste("Unexpected error:", conditionMessage(e)))
-      }
-    }
+  expect_error(
+    read_github_csv_dir(
+      "nonexistent-directory-that-should-not-exist",
+      ref = ref,
+      repo = repo,
+      token = token
+    ),
+    "not found|404",
+    ignore.case = TRUE
   )
 })


### PR DESCRIPTION
## Summary
- hardens GitHub URL/path resolution to reject non-GitHub remote URLs
- prevents PAT leakage by only attaching auth headers for GitHub hosts
- enables anonymous reads/listing for public GitHub content where possible
- improves 401/403/404/SSO error messaging
- updates docs + tests for the new behavior

## Why
Fixes the highest-risk finding from package review: potential credential exfiltration path when arbitrary URLs were accepted and auth headers were attached.

## Validation
- `Rscript -e 'devtools::test()'`
- result: `FAIL 0 | WARN 13 | SKIP 0 | PASS 663`
