### PR TITLE
Harden package writes, ontology fetch, and DwC validation

### DIFF
--- a/R/dwc-dp-export.R
+++ b/R/dwc-dp-export.R
@@ -57,12 +57,16 @@ dwc_dp_build_descriptor <- function(resources,
     return(invisible(NULL))
   }
 
-  tmp <- tempfile(fileext = ".json")
-  jsonlite::write_json(descriptor, tmp, auto_unbox = TRUE, pretty = TRUE)
+  descriptor_path <- tempfile(fileext = ".json")
+  script_path <- tempfile(fileext = ".py")
+  on.exit(unlink(c(descriptor_path, script_path), force = TRUE), add = TRUE)
 
-  cmd <- c(
-    "- <<'PY'",
-    "import json, sys",
+  jsonlite::write_json(descriptor, descriptor_path, auto_unbox = TRUE, pretty = TRUE)
+
+  script_lines <- c(
+    "import json",
+    "import sys",
+    "",
     "try:",
     "    import frictionless",
     "except ImportError:",
@@ -71,15 +75,20 @@ dwc_dp_build_descriptor <- function(resources,
     "",
     "pkg = frictionless.Package(sys.argv[1])",
     "report = pkg.validate()",
-    "print(report.flatten(['taskName','valid','errors']))",
-    "sys.exit(0 if report.valid else 1)",
-    "PY",
-    shQuote(tmp)
+    "print(report.flatten(['taskName', 'valid', 'errors']))",
+    "sys.exit(0 if report.valid else 1)"
   )
+  writeLines(script_lines, script_path, useBytes = TRUE)
 
-  status <- system2(py, cmd, stdout = TRUE, stderr = TRUE)
-  if (length(status) > 0) {
-    cat(paste(status, collapse = "\n"), "\n")
+  output <- system2(py, c(script_path, descriptor_path), stdout = TRUE, stderr = TRUE)
+  if (length(output) > 0) {
+    cat(paste(output, collapse = "\n"), "\n")
   }
+
+  status <- attr(output, "status")
+  if (is.null(status)) {
+    status <- 0L
+  }
+
   invisible(status)
 }

--- a/R/ontology_fetch.R
+++ b/R/ontology_fetch.R
@@ -5,14 +5,17 @@
 #'
 #' @param url Ontology URL. Default is the canonical SMN namespace root.
 #' @param accept Accept header; defaults to turtle with RDF/XML fallback.
-#' @param cache_dir Directory to store cached ontology and headers.
+#' @param cache_dir Directory to store cached ontology and headers. Defaults to
+#'   a persistent user cache path.
 #' @param fallback_urls Optional fallback ontology URLs tried if the primary `url` fails.
+#' @param timeout_seconds Numeric timeout in seconds for each HTTP request.
 #' @return Path to the cached ontology file (character string).
 #' @export
 fetch_salmon_ontology <- function(
     url = "https://w3id.org/smn/",
     accept = "text/turtle, application/rdf+xml;q=0.8",
-    cache_dir = file.path(tempdir(), "metasalmon-ontology-cache"),
+    cache_dir = file.path(tools::R_user_dir("metasalmon", which = "cache"), "ontology"),
+    timeout_seconds = 30,
     fallback_urls = c(
       "https://w3id.org/smn",
       "https://dfo-pacific-science.github.io/salmon-domain-ontology/smn.ttl"
@@ -25,10 +28,16 @@ fetch_salmon_ontology <- function(
 
   headers <- c(Accept = accept)
   if (file.exists(etag_file)) {
-    headers <- c(headers, `If-None-Match` = readLines(etag_file, warn = FALSE))
+    etag <- .ms_read_cached_header(etag_file)
+    if (!is.na(etag)) {
+      headers <- c(headers, `If-None-Match` = etag)
+    }
   }
   if (file.exists(lastmod_file)) {
-    headers <- c(headers, `If-Modified-Since` = readLines(lastmod_file, warn = FALSE))
+    last_modified <- .ms_read_cached_header(lastmod_file)
+    if (!is.na(last_modified)) {
+      headers <- c(headers, `If-Modified-Since` = last_modified)
+    }
   }
 
   urls <- c(url, fallback_urls)
@@ -36,9 +45,18 @@ fetch_salmon_ontology <- function(
   last_error <- NULL
 
   for (u in urls) {
-    res <- try(httr::GET(u, httr::add_headers(.headers = headers)), silent = TRUE)
+    res <- try(
+      httr::GET(
+        u,
+        httr::add_headers(.headers = headers),
+        httr::timeout(timeout_seconds),
+        httr::config(connecttimeout = timeout_seconds)
+      ),
+      silent = TRUE
+    )
     if (inherits(res, "try-error")) {
       last_error <- res
+      res <- NULL
       next
     }
     if (httr::status_code(res) %in% c(200, 304)) {
@@ -50,6 +68,13 @@ fetch_salmon_ontology <- function(
   }
 
   if (is.null(res)) {
+    if (file.exists(ttl_file)) {
+      cli::cli_warn(c(
+        "Failed to refresh Salmon ontology; using cached copy at {.path {ttl_file}}.",
+        "i" = "Last fetch error: {last_error}"
+      ))
+      return(ttl_file)
+    }
     stop("Failed to fetch ontology from provided URLs: ", paste(urls, collapse = ", "),
          "; last error: ", last_error)
   }
@@ -60,12 +85,29 @@ fetch_salmon_ontology <- function(
 
   httr::stop_for_status(res)
   content <- httr::content(res, as = "text", encoding = "UTF-8")
-  writeLines(content, ttl_file)
+  temp_ttl <- tempfile(tmpdir = cache_dir, fileext = ".ttl")
+  on.exit(unlink(temp_ttl, force = TRUE), add = TRUE)
+  writeLines(content, temp_ttl, useBytes = TRUE)
+  if (!file.rename(temp_ttl, ttl_file)) {
+    cli::cli_abort("Failed to update cached ontology file at {.path {ttl_file}}.")
+  }
 
   etag <- httr::headers(res)[["etag"]]
-  if (!is.null(etag)) writeLines(etag, etag_file)
+  if (!is.null(etag) && nzchar(etag)) writeLines(etag, etag_file, useBytes = TRUE)
   lastmod <- httr::headers(res)[["last-modified"]]
-  if (!is.null(lastmod)) writeLines(lastmod, lastmod_file)
+  if (!is.null(lastmod) && nzchar(lastmod)) writeLines(lastmod, lastmod_file, useBytes = TRUE)
 
   ttl_file
+}
+
+.ms_read_cached_header <- function(path) {
+  value <- readLines(path, warn = FALSE, n = 1)
+  if (length(value) == 0) {
+    return(NA_character_)
+  }
+  value <- trimws(value[[1]])
+  if (!nzchar(value)) {
+    return(NA_character_)
+  }
+  value
 }

--- a/R/package-helpers.R
+++ b/R/package-helpers.R
@@ -18,7 +18,9 @@
 #' @param codes Optional tibble with code lists
 #' @param path Character; directory path where package will be written
 #' @param format Character; resource format: `"csv"` (default, only format supported)
-#' @param overwrite Logical; if `FALSE` (default), errors if path exists
+#' @param overwrite Logical; if `FALSE` (default), errors if path exists. If
+#'   `TRUE`, replacement is only allowed for empty directories or directories
+#'   previously written by `metasalmon`.
 #'
 #' @return Invisibly returns the path to the created package
 #'
@@ -86,20 +88,7 @@ write_salmon_datapackage <- function(
 
   dataset_id <- dataset_meta$dataset_id[1]
 
-  # Check if path exists
-  if (dir.exists(path) && !overwrite) {
-    cli::cli_abort(
-      "Directory {.path {path}} already exists. Set {.code overwrite = TRUE} to replace."
-    )
-  }
-
-  # Create directory
-  if (!dir.exists(path)) {
-    dir.create(path, recursive = TRUE, showWarnings = FALSE)
-  } else if (overwrite) {
-    existing_files <- list.files(path, full.names = TRUE)
-    unlink(existing_files, recursive = TRUE)
-  }
+  .ms_prepare_package_write_dir(path, overwrite = overwrite)
 
   dir.create(.ms_metadata_dir(path), recursive = TRUE, showWarnings = FALSE)
 
@@ -233,8 +222,73 @@ write_salmon_datapackage <- function(
     auto_unbox = TRUE,
     null = "null"
   )
+  .ms_mark_package_ownership(path)
 
   cli::cli_alert_success("Created Salmon Data Package at {.path {path}}")
+  invisible(path)
+}
+
+.ms_package_sentinel_file <- function(path) {
+  file.path(path, ".metasalmon-package")
+}
+
+.ms_mark_package_ownership <- function(path) {
+  writeLines("metasalmon-owned", .ms_package_sentinel_file(path), useBytes = TRUE)
+  invisible(path)
+}
+
+.ms_dir_entries <- function(path) {
+  list.files(path, all.files = TRUE, no.. = TRUE, full.names = TRUE)
+}
+
+.ms_is_metasalmon_package_dir <- function(path) {
+  if (!dir.exists(path)) {
+    return(FALSE)
+  }
+
+  if (file.exists(.ms_package_sentinel_file(path))) {
+    return(TRUE)
+  }
+
+  has_sdp_csvs <- all(file.exists(c(
+    .ms_metadata_path(path, "dataset.csv"),
+    .ms_metadata_path(path, "tables.csv"),
+    .ms_metadata_path(path, "column_dictionary.csv")
+  )))
+  if (has_sdp_csvs) {
+    return(TRUE)
+  }
+
+  file.exists(file.path(path, "datapackage.json")) &&
+    dir.exists(file.path(path, "data")) &&
+    dir.exists(.ms_metadata_dir(path))
+}
+
+.ms_prepare_package_write_dir <- function(path, overwrite = FALSE) {
+  if (!dir.exists(path)) {
+    dir.create(path, recursive = TRUE, showWarnings = FALSE)
+    return(invisible(path))
+  }
+
+  if (!isTRUE(overwrite)) {
+    cli::cli_abort(
+      "Directory {.path {path}} already exists. Set {.code overwrite = TRUE} to replace."
+    )
+  }
+
+  existing_files <- .ms_dir_entries(path)
+  if (length(existing_files) == 0) {
+    return(invisible(path))
+  }
+
+  if (!.ms_is_metasalmon_package_dir(path)) {
+    cli::cli_abort(c(
+      "Refusing to overwrite non-metasalmon directory {.path {path}}.",
+      "i" = "Use a new/empty directory, or manually clean this directory first."
+    ))
+  }
+
+  unlink(existing_files, recursive = TRUE, force = TRUE)
   invisible(path)
 }
 
@@ -452,7 +506,9 @@ infer_salmon_datapackage_artifacts <- function(
 #'   [check_for_updates()] call after writing the package and mention newer
 #'   releases only when one is available. Defaults to `interactive()`.
 #' @param format Character; resource format: `"csv"` (default, only format supported)
-#' @param overwrite Logical; if `FALSE` (default), errors if path exists
+#' @param overwrite Logical; if `FALSE` (default), errors if path exists. If
+#'   `TRUE`, replacement is only allowed for empty directories or directories
+#'   previously written by `metasalmon`.
 #' @param include_edh_xml Logical; when `TRUE`, writes an EDH XML metadata file into
 #'   `metadata/` using `edh_build_iso19139_xml()`.
 #' @param edh_profile One of "dfo_edh_hnap" (default) or "iso19139". Determines

--- a/man/create_sdp.Rd
+++ b/man/create_sdp.Rd
@@ -72,7 +72,9 @@ releases only when one is available. Defaults to \code{interactive()}.}
 
 \item{format}{Character; resource format: \code{"csv"} (default, only format supported)}
 
-\item{overwrite}{Logical; if \code{FALSE} (default), errors if path exists}
+\item{overwrite}{Logical; if \code{FALSE} (default), errors if path exists. If
+\code{TRUE}, replacement is only allowed for empty directories or directories
+previously written by \code{metasalmon}.}
 
 \item{include_edh_xml}{Logical; when \code{TRUE}, writes an EDH XML metadata file into
 \verb{metadata/} using \code{edh_build_iso19139_xml()}.}

--- a/man/fetch_salmon_ontology.Rd
+++ b/man/fetch_salmon_ontology.Rd
@@ -7,7 +7,8 @@
 fetch_salmon_ontology(
   url = "https://w3id.org/smn/",
   accept = "text/turtle, application/rdf+xml;q=0.8",
-  cache_dir = file.path(tempdir(), "metasalmon-ontology-cache"),
+  cache_dir = file.path(tools::R_user_dir("metasalmon", which = "cache"), "ontology"),
+  timeout_seconds = 30,
   fallback_urls = c("https://w3id.org/smn",
     "https://dfo-pacific-science.github.io/salmon-domain-ontology/smn.ttl")
 )
@@ -17,7 +18,10 @@ fetch_salmon_ontology(
 
 \item{accept}{Accept header; defaults to turtle with RDF/XML fallback.}
 
-\item{cache_dir}{Directory to store cached ontology and headers.}
+\item{cache_dir}{Directory to store cached ontology and headers. Defaults to
+a persistent user cache path.}
+
+\item{timeout_seconds}{Numeric timeout in seconds for each HTTP request.}
 
 \item{fallback_urls}{Optional fallback ontology URLs tried if the primary \code{url} fails.}
 }

--- a/man/write_salmon_datapackage.Rd
+++ b/man/write_salmon_datapackage.Rd
@@ -30,7 +30,9 @@ write_salmon_datapackage(
 
 \item{format}{Character; resource format: \code{"csv"} (default, only format supported)}
 
-\item{overwrite}{Logical; if \code{FALSE} (default), errors if path exists}
+\item{overwrite}{Logical; if \code{FALSE} (default), errors if path exists. If
+\code{TRUE}, replacement is only allowed for empty directories or directories
+previously written by \code{metasalmon}.}
 }
 \value{
 Invisibly returns the path to the created package

--- a/tests/testthat/test-dwc-dp-export.R
+++ b/tests/testthat/test-dwc-dp-export.R
@@ -10,3 +10,18 @@ test_that("dwc_dp_build_descriptor builds minimal descriptor", {
   expect_equal(length(desc$resources), 2)
   expect_true(grepl("occurrence.json", desc$resources[[1]]$schema))
 })
+
+test_that("dwc frictionless validator runs without heredoc shell syntax", {
+  py <- Sys.which("python3")
+  testthat::skip_if(py == "", "python3 not available")
+
+  descriptor <- list(
+    profile = "http://rs.tdwg.org/dwc/dwc-dp",
+    name = "dwc-dp-export",
+    resources = list()
+  )
+
+  status <- .dwc_dp_validate_with_frictionless(descriptor, python = "python3")
+  expect_true(is.numeric(status))
+  expect_false(any(grepl("<<'PY'", deparse(body(.dwc_dp_validate_with_frictionless)), fixed = TRUE)))
+})

--- a/tests/testthat/test-package-helpers.R
+++ b/tests/testthat/test-package-helpers.R
@@ -908,3 +908,104 @@ test_that("write_salmon_datapackage errors on existing path without overwrite", 
     "already exists"
   )
 })
+
+test_that("write_salmon_datapackage refuses overwrite for non-metasalmon directories", {
+  temp_dir <- withr::local_tempdir()
+  writeLines("do not delete", file.path(temp_dir, "keep.txt"))
+
+  resources <- list(main_table = tibble::tibble(x = 1))
+  dataset_meta <- tibble::tibble(
+    dataset_id = "test-1",
+    title = "Test",
+    description = "Test",
+    creator = NA_character_,
+    contact_name = NA_character_,
+    contact_email = NA_character_,
+    license = NA_character_,
+    temporal_start = NA_character_,
+    temporal_end = NA_character_,
+    spatial_extent = NA_character_,
+    dataset_type = NA_character_,
+    source_citation = NA_character_
+  )
+  table_meta <- tibble::tibble(
+    dataset_id = "test-1",
+    table_id = "main_table",
+    file_name = "data/main_table.csv",
+    table_label = "Main",
+    description = NA_character_,
+    observation_unit = NA_character_,
+    observation_unit_iri = NA_character_,
+    primary_key = NA_character_
+  )
+  dict <- infer_dictionary(resources$main_table, dataset_id = "test-1", table_id = "main_table")
+  dict <- fill_measurement_components(dict)
+
+  expect_error(
+    write_salmon_datapackage(
+      resources,
+      dataset_meta,
+      table_meta,
+      dict,
+      path = temp_dir,
+      overwrite = TRUE
+    ),
+    "Refusing to overwrite non-metasalmon directory"
+  )
+  expect_true(file.exists(file.path(temp_dir, "keep.txt")))
+})
+
+test_that("write_salmon_datapackage can overwrite an existing metasalmon package", {
+  temp_dir <- withr::local_tempdir()
+
+  resources <- list(main_table = tibble::tibble(x = 1))
+  dataset_meta <- tibble::tibble(
+    dataset_id = "test-1",
+    title = "Test",
+    description = "Test",
+    creator = NA_character_,
+    contact_name = NA_character_,
+    contact_email = NA_character_,
+    license = NA_character_,
+    temporal_start = NA_character_,
+    temporal_end = NA_character_,
+    spatial_extent = NA_character_,
+    dataset_type = NA_character_,
+    source_citation = NA_character_
+  )
+  table_meta <- tibble::tibble(
+    dataset_id = "test-1",
+    table_id = "main_table",
+    file_name = "data/main_table.csv",
+    table_label = "Main",
+    description = NA_character_,
+    observation_unit = NA_character_,
+    observation_unit_iri = NA_character_,
+    primary_key = NA_character_
+  )
+  dict <- infer_dictionary(resources$main_table, dataset_id = "test-1", table_id = "main_table")
+  dict <- fill_measurement_components(dict)
+
+  write_salmon_datapackage(
+    resources,
+    dataset_meta,
+    table_meta,
+    dict,
+    path = temp_dir,
+    overwrite = TRUE
+  )
+  writeLines("stale", file.path(temp_dir, "stale.txt"))
+
+  write_salmon_datapackage(
+    resources,
+    dataset_meta,
+    table_meta,
+    dict,
+    path = temp_dir,
+    overwrite = TRUE
+  )
+
+  expect_false(file.exists(file.path(temp_dir, "stale.txt")))
+  expect_true(file.exists(file.path(temp_dir, ".metasalmon-package")))
+  expect_true(file.exists(file.path(temp_dir, "metadata", "dataset.csv")))
+})

--- a/tests/testthat/test-validation-helpers.R
+++ b/tests/testthat/test-validation-helpers.R
@@ -55,3 +55,21 @@ test_that("fetch_salmon_ontology returns a ttl path", {
   expect_true(file.exists(path))
   expect_match(path, "salmon-ontology\\.ttl$")
 })
+
+test_that("fetch_salmon_ontology falls back to stale cache when refresh fails", {
+  cache_dir <- withr::local_tempdir()
+  ttl_file <- file.path(cache_dir, "salmon-ontology.ttl")
+  writeLines("cached", ttl_file)
+
+  expect_warning(
+    path <- fetch_salmon_ontology(
+      url = "http://127.0.0.1:9/smn",
+      cache_dir = cache_dir,
+      fallback_urls = character(),
+      timeout_seconds = 1
+    ),
+    "using cached copy",
+    ignore.case = TRUE
+  )
+  expect_equal(path, ttl_file)
+})


### PR DESCRIPTION
## Summary
- hardens `write_salmon_datapackage()` overwrite behavior to avoid deleting arbitrary directories
- marks metasalmon-owned package directories with a sentinel and only allows safe overwrite targets
- fixes DwC validation helper to run Python validation script correctly via `system2()`
- adds ontology fetch request timeout + persistent cache path + stale-cache fallback
- adds tests covering overwrite safety, DwC validator invocation, and ontology fallback behavior

## Why
Addresses the major reliability/safety findings from review:
1) destructive overwrite footgun, 2) broken DwC validation execution path, 3) ontology fetch robustness gaps.

## Validation
- `Rscript -e 'devtools::test()'`
- result: `FAIL 0 | WARN 14 | SKIP 0 | PASS 660`
