### PR TITLE
Fix term-request repo routing and clean up semantics API

### DIFF
--- a/R/term-request-helpers.R
+++ b/R/term-request-helpers.R
@@ -550,7 +550,7 @@ submit_term_request_issues <- function(
     cli::cli_abort("Missing required request columns: {paste(missing, collapse = ', ')}")
   }
 
-  repo <- ms_normalize_repo(ifelse("ontology_repo" %in% names(requests), requests$ontology_repo[[1]], repo))
+  default_repo <- ms_normalize_repo(repo)
 
   pending <- requests[requests$request_scope %in% c("smn", "profile"), , drop = FALSE]
   if (nrow(pending) == 0L) {
@@ -580,6 +580,12 @@ submit_term_request_issues <- function(
     scope <- pending$request_scope[[i]]
     title <- pending$request_title[[i]]
     body <- pending$request_body[[i]]
+    repo_value <- pending$ontology_repo[[i]]
+    repo_i <- if (is.na(repo_value) || !nzchar(trimws(repo_value))) {
+      default_repo
+    } else {
+      ms_normalize_repo(repo_value)
+    }
     lbls <- if ("issue_labels" %in% names(pending)) pending$issue_labels[[i]] else NULL
 
     if (is.list(lbls) && length(lbls) == 0L) {
@@ -597,7 +603,7 @@ submit_term_request_issues <- function(
     }
 
     resp <- .metasalmon_post_issue(
-      repo = repo,
+      repo = repo_i,
       title = title,
       body = body,
       labels = lbls,

--- a/R/validation_helpers.R
+++ b/R/validation_helpers.R
@@ -12,9 +12,10 @@
 #' @param require_iris Logical; if TRUE, require non-empty semantic fields
 #'   (`term_iri`, `property_iri`, `entity_iri`, `unit_iri`) for measurement
 #'   rows.
-#' @param entity_defaults Optional data frame with `table_prefix` and `entity_iri`
-#'   (not applied automatically here but reserved for future use).
-#' @param vocab_priority Optional character vector of vocab sources (reserved).
+#' @param entity_defaults Deprecated and ignored. Previously reserved for future
+#'   default entity mapping.
+#' @param vocab_priority Deprecated and ignored. Previously reserved for future
+#'   vocabulary ordering.
 #'
 #' @return A list with elements:
 #'   - `dict`: normalized dictionary with `required` column.
@@ -27,6 +28,13 @@ validate_semantics <- function(dict,
                                require_iris = FALSE,
                                entity_defaults = NULL,
                                vocab_priority = NULL) {
+  if (!is.null(entity_defaults)) {
+    cli::cli_warn("{.arg entity_defaults} is deprecated in {.fn validate_semantics} and is ignored.")
+  }
+  if (!is.null(vocab_priority)) {
+    cli::cli_warn("{.arg vocab_priority} is deprecated in {.fn validate_semantics} and is ignored.")
+  }
+
   if (!"required" %in% names(dict)) {
     dict$required <- rep(NA, nrow(dict))
   }

--- a/man/validate_semantics.Rd
+++ b/man/validate_semantics.Rd
@@ -18,10 +18,11 @@ validate_semantics(
 (\code{term_iri}, \code{property_iri}, \code{entity_iri}, \code{unit_iri}) for measurement
 rows.}
 
-\item{entity_defaults}{Optional data frame with \code{table_prefix} and \code{entity_iri}
-(not applied automatically here but reserved for future use).}
+\item{entity_defaults}{Deprecated and ignored. Previously reserved for future
+default entity mapping.}
 
-\item{vocab_priority}{Optional character vector of vocab sources (reserved).}
+\item{vocab_priority}{Deprecated and ignored. Previously reserved for future
+vocabulary ordering.}
 }
 \value{
 A list with elements:

--- a/tests/testthat/test-term-request-helpers.R
+++ b/tests/testthat/test-term-request-helpers.R
@@ -129,3 +129,31 @@ test_that("submit_term_request_issues dry run and mock post", {
     }
   )
 })
+
+test_that("submit_term_request_issues posts each request to its row-level ontology repo", {
+  reqs <- tibble::tibble(
+    request_title = c("Request A", "Request B"),
+    request_body = c("body a", "body b"),
+    request_scope = c("smn", "profile"),
+    ontology_repo = c(
+      "dfo-pacific-science/dfo-salmon-ontology",
+      "dfo-pacific-science/salmon-profile-ontology"
+    ),
+    issue_labels = list(NULL, NULL)
+  )
+
+  called_repos <- character()
+  with_mocked_bindings(
+    .metasalmon_post_issue = function(repo, ...) {
+      called_repos <<- c(called_repos, repo)
+      list(number = 1L, html_url = paste0("https://github.com/", repo, "/issues/1"))
+    },
+    {
+      submitted <- submit_term_request_issues(reqs, dry_run = FALSE, confirm = FALSE, token = "test-token")
+      expect_equal(nrow(submitted), 2L)
+      expect_equal(submitted$status, c("submitted", "submitted"))
+    }
+  )
+
+  expect_equal(called_repos, reqs$ontology_repo)
+})

--- a/tests/testthat/test-validation-helpers.R
+++ b/tests/testthat/test-validation-helpers.R
@@ -49,6 +49,34 @@ test_that("validate_semantics flags non-canonical salmon ontology IRIs", {
   expect_true(any(grepl("non-canonical GCDFO CURIE form", res$issues$message, fixed = TRUE)))
 })
 
+test_that("validate_semantics warns that deprecated arguments are ignored", {
+  dict <- tibble::tibble(
+    dataset_id = "d1",
+    table_id = "t1",
+    column_name = "count",
+    column_label = "Count",
+    column_description = "Fish count",
+    column_role = "measurement",
+    value_type = "integer",
+    term_iri = "",
+    property_iri = NA_character_,
+    entity_iri = NA_character_,
+    unit_iri = NA_character_,
+    constraint_iri = "",
+    method_iri = ""
+  )
+
+  expect_warning(
+    res <- validate_semantics(dict, entity_defaults = tibble::tibble(table_prefix = "t", entity_iri = "https://w3id.org/smn/Stock")),
+    "entity_defaults.*deprecated.*ignored"
+  )
+  expect_warning(
+    res <- validate_semantics(dict, vocab_priority = c("smn", "gcdfo")),
+    "vocab_priority.*deprecated.*ignored"
+  )
+  expect_equal(nrow(res$missing_terms), 1L)
+})
+
 test_that("fetch_salmon_ontology returns a ttl path", {
   testthat::skip_if_offline("w3id.org")
   path <- fetch_salmon_ontology()


### PR DESCRIPTION
## Summary
- fixes `submit_term_request_issues()` so each request row posts to its own `ontology_repo`
- cleans up `validate_semantics()` API by explicitly deprecating ignored `entity_defaults` / `vocab_priority` args
- adds tests for mixed-repo submission behavior and deprecation warnings
- updates docs for the API clarification

## Why
Addresses API correctness and confusing surface-area findings from review, while preserving backwards compatibility.

## Validation
- `Rscript -e 'devtools::test()'`
- result: `FAIL 0 | WARN 15 | SKIP 0 | PASS 657`
