### PR TITLE
Release 0.0.20

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: metasalmon
 Type: Package
 Title: Utilities for Salmon Data Packages
-Version: 0.0.19
+Version: 0.0.20
 Authors@R: c(person(given = "Brett", family = "Johnson", role = c("aut", "cre"), email = "brettthomasjohnson@gmail.com"))
 Maintainer: Brett Johnson <brettthomasjohnson@gmail.com>
 Description: Tools to scaffold, standardize, validate, transform, and package

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+metasalmon 0.0.20
+----------------
+
+- Hardened GitHub helper security: GitHub readers now reject non-GitHub remote URLs and avoid attaching GitHub auth headers to non-GitHub hosts; improved public/private auth behavior and related tests.
+- Hardened package writing + export reliability: safer overwrite behavior for package outputs, fixed DwC validator execution path, and improved ontology fetch robustness with explicit timeout handling and cache fallback behavior.
+- Fixed `submit_term_request_issues()` batch routing so per-row `ontology_repo` values are honored instead of posting all rows to the first repo.
+- Clarified `validate_semantics()` API by explicitly deprecating ignored legacy arguments (`entity_defaults`, `vocab_priority`) with coverage for warning behavior.
+- Improved release/test hygiene: dependency bootstrap script hardening, tighter warning assertions in brittle tests, and refreshed package description wording.
+
 metasalmon 0.0.19
 ----------------
 


### PR DESCRIPTION
## Summary
- bump package version to 0.0.20
- add consolidated release notes for the hardening/robustness fixes merged in this batch

## Validation
- `Rscript -e 'devtools::test()'`
- result: `FAIL 0 | WARN 16 | SKIP 0 | PASS 678`
