### PR TITLE
Guard method-like fields from measurement role

### DIFF
--- a/R/dictionary-helpers.R
+++ b/R/dictionary-helpers.R
@@ -581,6 +581,16 @@ infer_column_role <- function(col_name, col) {
     return("categorical")
   }
 
+  # Method/protocol-like fields are metadata, not measurements, even when
+  # their names contain count/measure substrings (for example counting_method).
+  method_tokens <- c(
+    "method", "methods", "protocol", "protocols", "procedure", "procedures",
+    "technique", "techniques", "gear", "enumeration"
+  )
+  if (any(name_tokens %in% method_tokens)) {
+    return("attribute")
+  }
+
   # Check for measurement/quantity patterns
   measurement_tokens <- c(
     "count", "counts", "total", "totals", "number", "numbers", "amount", "quantity",

--- a/tests/testthat/test-dictionary-helpers.R
+++ b/tests/testthat/test-dictionary-helpers.R
@@ -73,6 +73,22 @@ test_that("infer_dictionary better distinguishes temporal and measurement NuSEDS
   expect_equal(dict$column_role[dict$column_name == "POP_ID"], "identifier")
 })
 
+test_that("infer_dictionary keeps method-like count fields out of measurement role", {
+  df <- tibble::tibble(
+    counting_method = c("Visual", "Electronic"),
+    measurement_method = c("Direct", "Estimated"),
+    cwt_1st_mark_count = c(12, 15),
+    avg_weight = c(0.3, 0.5)
+  )
+
+  dict <- infer_dictionary(df, dataset_id = "test-1", table_id = "table-1")
+
+  expect_equal(dict$column_role[dict$column_name == "counting_method"], "attribute")
+  expect_equal(dict$column_role[dict$column_name == "measurement_method"], "attribute")
+  expect_equal(dict$column_role[dict$column_name == "cwt_1st_mark_count"], "measurement")
+  expect_equal(dict$column_role[dict$column_name == "avg_weight"], "measurement")
+})
+
 test_that("infer_dictionary can seed semantic suggestions", {
   fake_suggest <- function(df, dict, sources = c("ols", "nvs"), max_per_role = 1, include_dwc = FALSE,
                            codes = NULL, table_meta = NULL, dataset_meta = NULL, ...) {


### PR DESCRIPTION
## Summary
- guard method/protocol/procedure/gear/enumeration-like column names from the measurement role before count/measure substring matching
- add focused regression coverage for `counting_method` and `measurement_method` while keeping real measurement controls (`cwt_1st_mark_count`, `avg_weight`) classified as measurements

## Why
The semantic suggestion lab found a narrow, high-confidence production bug: method-like fields such as `counting_method` were being inferred as measurements, which forced bogus decomposition into `term_iri` / `property_iri` / related measurement fields.

Recent evidence:
- CWT release-data control: `counting_method` was previously misclassified as a measurement and now stays an attribute
- Atlantic salmon captured in BC negative control: reviewed attribute-heavy fields stayed out of measurement decomposition

## Verification
- `Rscript -e 'devtools::test_file("tests/testthat/test-dictionary-helpers.R")'`
- real `create_sdp()` rerun on Atlantic salmon captured in BC slice
- real `create_sdp()` rerun on CWT release-data slice
- `Rscript -e "devtools::test()"` (689 pass, 0 fail, 16 warnings)
