### PR TITLE
Improve count-like semantic ranking

### DIFF
--- a/R/semantics-helpers.R
+++ b/R/semantics-helpers.R
@@ -215,10 +215,13 @@ suggest_semantics <- function(df,
 
     has_explicit_count <- grepl("\\b(count|counts|number|numbers|num|abundance)\\b", text)
     has_total <- grepl("\\btotal\\b", text)
-    has_organism <- grepl("\\b(spawner|spawners|fish|salmon|organism|organisms|recruit|recruits|population|populations)\\b", text)
-    looks_integer <- value_type %in% c("integer", "int")
+    has_organism <- grepl("\\b(spawner|spawners|fish|salmon|organism|organisms|recruit|recruits|population|populations|adult|adults)\\b", text)
+    looks_integer <- value_type %in% c("integer", "int", "number", "numeric", "double")
 
-    has_explicit_count || (has_total && has_organism) || (grepl("\\babundance\\b", text) && (has_organism || looks_integer))
+    has_explicit_count ||
+      (has_total && has_organism) ||
+      (grepl("\\babundance\\b", text) && (has_organism || looks_integer)) ||
+      (looks_integer && has_organism)
   }
   measurement_role_query <- function(row, dict, role_name) {
     desc_query <- if (is_review_placeholder(row$column_description[[1]])) {
@@ -266,12 +269,22 @@ suggest_semantics <- function(df,
     }
 
     if (role_name %in% c("variable", "property")) {
-      if (grepl("spawner", base_lower) && grepl("total|count|number", base_lower)) {
-        if (identical(role_name, "variable")) return("spawner abundance")
-        return("abundance")
-      }
-      if (is_count_like_measurement(row, base_query) && identical(role_name, "property")) {
-        if (grepl("\\babundance\\b", base_lower)) return("abundance")
+      if (is_count_like_measurement(row, base_query)) {
+        if (grepl("spawner", base_lower)) {
+          if (identical(role_name, "variable")) {
+            if (grepl("adult", base_lower)) return("adult spawner count")
+            return("spawner abundance")
+          }
+          return("count")
+        }
+
+        if (grepl("\\babundance\\b", base_lower)) {
+          return("abundance")
+        }
+
+        if (identical(role_name, "variable")) {
+          return("count")
+        }
         return("count")
       }
     }

--- a/R/term_search.R
+++ b/R/term_search.R
@@ -232,7 +232,7 @@ find_terms <- function(query,
       for (local_src in local_pref_sources) {
         local_res <- run_source(local_src)
         query_results[[length(query_results) + 1]] <- local_res
-        local_good_hit <- nrow(local_res) > 0 && any(local_res$match_type %in% c("label_exact", "label_partial"))
+        local_good_hit <- .local_short_circuit_hit(q, local_res)
         if (local_good_hit) {
           return(query_results)
         }
@@ -756,6 +756,116 @@ pattern <- paste(tokens, collapse = ".*")
 .query_tokens <- function(x) {
   tokens <- unique(strsplit(gsub("[^a-z0-9]+", " ", tolower(x)), "\\s+")[[1]])
   tokens[nzchar(tokens)]
+}
+
+.label_token_overlap <- function(query, label) {
+  q_tokens <- .query_tokens(query %||% "")
+  label_tokens <- .query_tokens(label %||% "")
+  if (length(q_tokens) == 0 || length(label_tokens) == 0) {
+    return(0)
+  }
+
+  length(intersect(q_tokens, label_tokens))
+}
+
+.is_count_like_query <- function(query, role = NA_character_) {
+  role <- tolower(trimws(role %||% ""))
+  if (!role %in% c("variable", "property")) {
+    return(FALSE)
+  }
+
+  q_tokens <- .query_tokens(query %||% "")
+  if (length(q_tokens) == 0) {
+    return(FALSE)
+  }
+
+  any(q_tokens %in% c("count", "counts", "number", "numbers", "abundance", "spawner", "spawners"))
+}
+
+.count_like_query_bonus <- function(query, label, role = NA_character_) {
+  if (!.is_count_like_query(query, role)) {
+    return(0)
+  }
+
+  q_tokens <- .query_tokens(query %||% "")
+  label_tokens <- .query_tokens(label %||% "")
+  if (length(q_tokens) == 0 || length(label_tokens) == 0) {
+    return(0)
+  }
+
+  q_has_count <- any(q_tokens %in% c("count", "counts", "number", "numbers"))
+  q_has_abundance <- "abundance" %in% q_tokens
+  q_has_spawner <- any(q_tokens %in% c("spawner", "spawners"))
+  q_has_rate <- "rate" %in% q_tokens
+  q_has_mortality <- any(q_tokens %in% c("mortality", "mortalities"))
+  q_has_exploitation <- any(q_tokens %in% c("exploitation", "exploit"))
+  q_has_benchmark <- any(q_tokens %in% c("benchmark", "benchmarks"))
+
+  label_norm <- tolower(trimws(label %||% ""))
+  label_has_count <- any(label_tokens %in% c("count", "counts", "number", "numbers"))
+  label_has_abundance <- "abundance" %in% label_tokens
+  label_has_spawner <- any(label_tokens %in% c("spawner", "spawners"))
+  label_has_unit <- "unit" %in% label_tokens
+  label_has_rate <- "rate" %in% label_tokens
+  label_has_mortality <- any(label_tokens %in% c("mortality", "mortalities"))
+  label_has_exploitation <- any(label_tokens %in% c("exploitation", "exploit"))
+  label_has_benchmark <- any(label_tokens %in% c("benchmark", "benchmarks"))
+
+  bonus <- 0
+
+  if (q_has_count && label_has_count) {
+    bonus <- bonus + 4
+  }
+  if (q_has_abundance && label_has_abundance) {
+    bonus <- bonus + 3
+  }
+  if (q_has_spawner && label_has_spawner) {
+    bonus <- bonus + 2.5
+  }
+  if (q_has_count && q_has_spawner && label_has_abundance && label_has_spawner) {
+    bonus <- bonus + 1.5
+  }
+  if (q_has_count && identical(label_norm, "count")) {
+    bonus <- bonus + 3
+  }
+  if (q_has_abundance && identical(label_norm, "abundance")) {
+    bonus <- bonus + 3
+  }
+
+  if (q_has_count && !q_has_spawner && label_has_spawner) {
+    bonus <- bonus - 2.5
+  }
+  if (label_has_unit) {
+    bonus <- bonus - 4
+  }
+  if (!q_has_rate && label_has_rate) {
+    bonus <- bonus - 2.5
+  }
+  if (!q_has_mortality && label_has_mortality) {
+    bonus <- bonus - 3
+  }
+  if (!q_has_exploitation && label_has_exploitation) {
+    bonus <- bonus - 3
+  }
+  if (!q_has_benchmark && label_has_benchmark) {
+    bonus <- bonus - 3
+  }
+
+  bonus
+}
+
+.local_short_circuit_hit <- function(query, results) {
+  if (nrow(results) == 0) {
+    return(FALSE)
+  }
+
+  label_hits <- results$match_type %in% c("label_exact", "label_partial")
+  if (!any(label_hits)) {
+    return(FALSE)
+  }
+
+  overlaps <- vapply(results$label %||% "", function(lbl) .label_token_overlap(query, lbl), numeric(1))
+  any(label_hits & overlaps > 0)
 }
 
 .first_non_empty_chr <- function(x) {
@@ -1576,6 +1686,16 @@ sources_for_role <- function(role) {
         }
       }, numeric(1))
     }
+
+    if (.is_count_like_query(query, role_key)) {
+      df$score <- df$score + vapply(df$label, function(lbl) {
+        .count_like_query_bonus(query, lbl, role_key)
+      }, numeric(1))
+    }
+  }
+
+  if (identical(role_key, "variable") && "match_type" %in% names(df)) {
+    df$score <- df$score + ifelse(grepl("property$", df$match_type %||% "", ignore.case = TRUE), -0.5, 0)
   }
 
   # ZOOMA confidence weighting

--- a/tests/testthat/fixtures/semantic-ranking-fixtures.json
+++ b/tests/testthat/fixtures/semantic-ranking-fixtures.json
@@ -817,5 +817,143 @@
         "backend_score": 1.0
       }
     ]
+  },
+  {
+    "case_id": "count-like-property-prefers-explicit-count",
+    "query": "count",
+    "role": "property",
+    "expected": {
+      "top": {
+        "candidate_id": "ols-count",
+        "source": "ols"
+      }
+    },
+    "candidates": [
+      {
+        "candidate_id": "smn-observed-rate-abundance",
+        "label": "Observed rate or abundance",
+        "iri": "https://w3id.org/smn/ObservedRateOrAbundance",
+        "source": "smn",
+        "ontology": "smn",
+        "role": "property",
+        "match_type": "definition",
+        "definition": "Observed count or abundance metric.",
+        "backend_score": 3.0
+      },
+      {
+        "candidate_id": "gcdfo-spawner-abundance",
+        "label": "Spawner abundance",
+        "iri": "https://w3id.org/gcdfo/salmon#SpawnerAbundance",
+        "source": "gcdfo",
+        "ontology": "gcdfo",
+        "role": "property",
+        "match_type": "label_partial",
+        "definition": "Spawner abundance estimate.",
+        "backend_score": 2.8
+      },
+      {
+        "candidate_id": "ols-count",
+        "label": "count",
+        "iri": "http://purl.obolibrary.org/obo/STATO_0000047",
+        "source": "ols",
+        "ontology": "stato",
+        "role": "property",
+        "match_type": "label_exact",
+        "definition": "Count of observed entities.",
+        "backend_score": 0.8
+      }
+    ]
+  },
+  {
+    "case_id": "count-like-variable-prefers-explicit-count-over-rate",
+    "query": "cwt 1st mark count",
+    "role": "variable",
+    "expected": {
+      "top": {
+        "candidate_id": "ols-count",
+        "source": "ols"
+      }
+    },
+    "candidates": [
+      {
+        "candidate_id": "smn-observed-rate-abundance",
+        "label": "Observed rate or abundance",
+        "iri": "https://w3id.org/smn/ObservedRateOrAbundance",
+        "source": "smn",
+        "ontology": "smn",
+        "role": "variable",
+        "match_type": "class",
+        "definition": "Observed count or abundance metric.",
+        "backend_score": 3.0
+      },
+      {
+        "candidate_id": "gcdfo-cwt-survival",
+        "label": "CWT marine survival rate",
+        "iri": "https://w3id.org/gcdfo/salmon#CWTMarineSurvivalRate",
+        "source": "gcdfo",
+        "ontology": "gcdfo",
+        "role": "variable",
+        "match_type": "class",
+        "definition": "Coded-wire-tag marine survival rate.",
+        "backend_score": 2.4
+      },
+      {
+        "candidate_id": "ols-count",
+        "label": "count",
+        "iri": "http://purl.obolibrary.org/obo/NCIT_C25463",
+        "source": "ols",
+        "ontology": "ncit",
+        "role": "variable",
+        "match_type": "class",
+        "definition": "Count of observed entities.",
+        "backend_score": 0.9
+      }
+    ]
+  },
+  {
+    "case_id": "count-like-spawner-query-prefers-spawner-abundance",
+    "query": "adult spawner count",
+    "role": "variable",
+    "expected": {
+      "top": {
+        "candidate_id": "gcdfo-spawner-abundance",
+        "source": "gcdfo"
+      }
+    },
+    "candidates": [
+      {
+        "candidate_id": "smn-observed-rate-abundance",
+        "label": "Observed rate or abundance",
+        "iri": "https://w3id.org/smn/ObservedRateOrAbundance",
+        "source": "smn",
+        "ontology": "smn",
+        "role": "variable",
+        "match_type": "class",
+        "definition": "Observed count or abundance metric.",
+        "backend_score": 3.0
+      },
+      {
+        "candidate_id": "smn-exploitation-rate",
+        "label": "Exploitation rate",
+        "iri": "https://w3id.org/smn/ExploitationRate",
+        "source": "smn",
+        "ontology": "smn",
+        "role": "variable",
+        "match_type": "class",
+        "definition": "Fishery exploitation rate.",
+        "backend_score": 2.9
+      },
+      {
+        "candidate_id": "gcdfo-spawner-abundance",
+        "label": "Spawner abundance",
+        "iri": "https://w3id.org/gcdfo/salmon#SpawnerAbundance",
+        "source": "gcdfo",
+        "ontology": "gcdfo",
+        "role": "variable",
+        "match_type": "class",
+        "definition": "Spawner abundance estimate.",
+        "backend_score": 2.7
+      }
+    ]
   }
 ]

--- a/tests/testthat/test-dictionary-helpers.R
+++ b/tests/testthat/test-dictionary-helpers.R
@@ -260,7 +260,7 @@ test_that("suggest_semantics captures suggestions with dictionary_role and colum
   expect_true(all(suggestions$table_id == "t1"))
   expect_true(all(suggestions$target_scope == "column"))
   expect_true(all(suggestions$target_sdp_file == "column_dictionary.csv"))
-  expect_equal(suggestions$search_query[suggestions$dictionary_role == "variable"], "Spawner abundance estimate")
+  expect_equal(suggestions$search_query[suggestions$dictionary_role == "variable"], "spawner abundance")
   expect_equal(suggestions$search_query[suggestions$dictionary_role == "unit"], "count")
   expect_equal(suggestions$search_query[suggestions$dictionary_role == "entity"], "population")
   expect_equal(
@@ -316,9 +316,50 @@ test_that("suggest_semantics strips review placeholders and applies role-aware c
   call_df <- tibble::as_tibble(purrr::map_dfr(calls, tibble::as_tibble))
   expect_true(any(call_df$role == "unit" & call_df$query == "count"))
   expect_true(any(call_df$role == "variable" & call_df$query == "spawner abundance"))
-  expect_true(any(call_df$role == "property" & call_df$query == "abundance"))
+  expect_true(any(call_df$role == "property" & call_df$query == "count"))
   expect_true(any(call_df$role == "constraint" & call_df$query == "natural origin"))
   expect_true(any(call_df$role == "entity" & call_df$query == "population"))
+})
+
+test_that("suggest_semantics uses count-like measurement queries for adult spawner and mark-count fields", {
+  dict <- tibble::tibble(
+    dataset_id = c("d1", "d1"),
+    table_id = c("t1", "t1"),
+    column_name = c("NATURAL_ADULT_SPAWNERS", "cwt_1st_mark_count"),
+    column_label = c("NATURAL_ADULT_SPAWNERS", "cwt_1st_mark_count"),
+    column_description = c("Estimated natural-origin adult spawners", "First-mark coded-wire-tag count"),
+    column_role = c("measurement", "measurement"),
+    value_type = c("integer", "integer"),
+    unit_label = c(NA_character_, NA_character_),
+    unit_iri = c(NA_character_, NA_character_),
+    term_iri = c(NA_character_, NA_character_),
+    property_iri = c(NA_character_, NA_character_),
+    entity_iri = c(NA_character_, NA_character_),
+    constraint_iri = c(NA_character_, NA_character_),
+    method_iri = c(NA_character_, NA_character_)
+  )
+
+  calls <- list()
+  fake_search <- function(query, role, sources) {
+    calls[[length(calls) + 1]] <<- list(query = query, role = role)
+    tibble::tibble(
+      label = paste("candidate", role),
+      iri = paste0("https://example.org/", role),
+      source = "ols",
+      ontology = "demo",
+      role = role,
+      match_type = "label_partial",
+      definition = ""
+    )
+  }
+
+  suggest_semantics(NULL, dict, sources = "ols", max_per_role = 1, search_fn = fake_search)
+
+  call_df <- tibble::as_tibble(purrr::map_dfr(calls, tibble::as_tibble))
+  expect_true(any(call_df$role == "variable" & call_df$query == "adult spawner count"))
+  expect_true(any(call_df$role == "property" & call_df$query == "count"))
+  expect_true(any(call_df$role == "variable" & call_df$query == "count"))
+  expect_true(any(call_df$role == "unit" & call_df$query == "count"))
 })
 
 test_that("suggest_semantics ignores review placeholders when building table observation-unit queries", {

--- a/tests/testthat/test-term-search.R
+++ b/tests/testthat/test-term-search.R
@@ -279,6 +279,47 @@ test_that("find_terms falls back to gcdfo when smn has no good hit", {
   expect_equal(res$label[[1]], "Stock")
 })
 
+test_that("find_terms does not short-circuit on lexical-poor local count hits", {
+  smn_rows <- tibble::tibble(
+    label = "Observed rate or abundance",
+    iri = "https://w3id.org/smn/ObservedRateOrAbundance",
+    source = "smn",
+    ontology = "smn",
+    role = "property",
+    match_type = "definition",
+    definition = "Observed count or abundance metric."
+  )
+  gcdfo_rows <- tibble::tibble(
+    label = "Spawner abundance",
+    iri = "https://w3id.org/gcdfo/salmon#SpawnerAbundance",
+    source = "gcdfo",
+    ontology = "gcdfo",
+    role = "property",
+    match_type = "label_partial",
+    definition = "Spawner abundance estimate."
+  )
+  ols_rows <- tibble::tibble(
+    label = "count",
+    iri = "http://purl.obolibrary.org/obo/STATO_0000047",
+    source = "ols",
+    ontology = "stato",
+    role = "property",
+    match_type = "label_exact",
+    definition = "count"
+  )
+
+  res <- with_mocked_bindings(
+    .search_smn = function(query, role) smn_rows,
+    .search_gcdfo = function(query, role) gcdfo_rows,
+    .search_ols = function(query, role) ols_rows,
+    .search_nvs = function(query, role) .empty_terms(role),
+    find_terms("count", role = "property", sources = c("smn", "gcdfo", "ols", "nvs"), expand_query = FALSE)
+  )
+
+  expect_true("ols" %in% res$source)
+  expect_equal(res$label[[1]], "count")
+})
+
 test_that("score_and_rank_terms boosts label overlap with query tokens", {
   df <- tibble::tibble(
     label = c("Spawner count", "Natural killer cell"),


### PR DESCRIPTION
## Summary
- normalize count-like measurement query planning so adult spawner and mark-count fields search as bounded count/spawner concepts
- tighten local short-circuiting and add count-like ranking bonuses/penalties so exact count concepts beat unrelated rate/benchmark hits
- add regression coverage for count-like query planning, lexical fallback, and ranking fixtures

## Verification
- Rscript -e "devtools::test(filter = 'term-search')"
- Rscript -e "devtools::test(filter = 'dictionary-helpers')"
- real `create_sdp()` retest on bundled NuSEDS Fraser coho example and CWT release data slice
- Rscript -e "devtools::test()"
