### PR TITLE
Improve generic entity semantic ranking

### DIFF
--- a/R/semantics-helpers.R
+++ b/R/semantics-helpers.R
@@ -299,6 +299,7 @@ suggest_semantics <- function(df,
     replacements <- c(
       "\\bcu\\b" = "conservation unit",
       "\\bcus\\b" = "conservation units",
+      "\\bwaterbody\\b" = "water body",
       "\\bcde\\b" = "code",
       "\\bdtt\\b" = "date time",
       "\\byr\\b" = "year",
@@ -371,10 +372,10 @@ suggest_semantics <- function(df,
       if (grepl("\\bspecies\\b|\\btaxon\\b", all_text, perl = TRUE)) return("species")
       if (grepl("\\bpopulation\\b", all_text, perl = TRUE)) return("population")
       if (grepl("\\bwatershed\\b", all_text, perl = TRUE)) return("watershed")
-      if (grepl("\\bwaterbody\\b|\\briver\\b|\\bstream\\b", all_text, perl = TRUE)) return("waterbody")
+      if (grepl("\\bwaterbody\\b|\\briver\\b|\\bstream\\b", all_text, perl = TRUE)) return("water body")
       if (grepl("\\bsite\\b|\\blocation\\b", all_text, perl = TRUE)) return("site")
       if (grepl("\\barea\\b", all_text, perl = TRUE)) {
-        if (context_has(ctx, "waterbody|watershed|river|stream")) return("waterbody")
+        if (context_has(ctx, "waterbody|watershed|river|stream")) return("water body")
         return("area")
       }
     }

--- a/R/term_search.R
+++ b/R/term_search.R
@@ -854,6 +854,66 @@ pattern <- paste(tokens, collapse = ".*")
   bonus
 }
 
+.is_generic_entity_query <- function(query, role = NA_character_) {
+  role <- tolower(trimws(role %||% ""))
+  if (!identical(role, "entity")) {
+    return(FALSE)
+  }
+
+  query_tokens <- .query_tokens(query %||% "")
+  if (length(query_tokens) == 0) {
+    return(FALSE)
+  }
+
+  generic_tokens <- c(
+    "species", "taxon", "population", "stock", "conservation", "unit",
+    "watershed", "water", "body", "river", "stream", "site", "location", "area"
+  )
+
+  all(query_tokens %in% generic_tokens)
+}
+
+.generic_entity_query_adjustment <- function(query, label, iri, source, match_type, role = NA_character_) {
+  if (!.is_generic_entity_query(query, role)) {
+    return(0)
+  }
+
+  query_tokens <- .query_tokens(query %||% "")
+  label_tokens <- .query_tokens(label %||% "")
+  coverage <- if (length(query_tokens) == 0) {
+    0
+  } else {
+    length(intersect(query_tokens, label_tokens)) / length(query_tokens)
+  }
+
+  iri <- iri %||% ""
+  source <- tolower(trimws(source %||% ""))
+  match_type <- tolower(trimws(match_type %||% ""))
+
+  is_local <- source %in% c("smn", "gcdfo")
+  has_taxon_signal <- any(query_tokens %in% c("species", "taxon"))
+  has_spatial_signal <- any(query_tokens %in% c("watershed", "water", "body", "river", "stream", "site", "location", "area"))
+
+  bonus <- 0
+
+  if (is_local && coverage < 1) {
+    bonus <- bonus - (4 * (1 - coverage))
+  }
+  if (identical(match_type, "definition") && coverage == 0) {
+    bonus <- bonus - 2
+  }
+
+  if (has_taxon_signal && grepl("http://purl\\.obolibrary\\.org/obo/NCBITaxon_", iri, ignore.case = TRUE)) {
+    bonus <- bonus + 3
+  }
+
+  if (has_spatial_signal && grepl("http://purl\\.obolibrary\\.org/obo/ENVO_", iri, ignore.case = TRUE) && coverage > 0) {
+    bonus <- bonus + 2.5
+  }
+
+  bonus
+}
+
 .local_short_circuit_hit <- function(query, results) {
   if (nrow(results) == 0) {
     return(FALSE)
@@ -1690,6 +1750,19 @@ sources_for_role <- function(role) {
     if (.is_count_like_query(query, role_key)) {
       df$score <- df$score + vapply(df$label, function(lbl) {
         .count_like_query_bonus(query, lbl, role_key)
+      }, numeric(1))
+    }
+
+    if (identical(role_key, "entity")) {
+      df$score <- df$score + vapply(seq_len(nrow(df)), function(i) {
+        .generic_entity_query_adjustment(
+          query = query,
+          label = df$label[[i]],
+          iri = df$iri[[i]],
+          source = df$source[[i]],
+          match_type = df$match_type[[i]],
+          role = role_key
+        )
       }, numeric(1))
     }
   }

--- a/tests/testthat/test-dictionary-helpers.R
+++ b/tests/testthat/test-dictionary-helpers.R
@@ -549,6 +549,61 @@ test_that("suggest_semantics uses role-aware search roles for controlled attribu
   expect_true(all(column_suggestions$target_sdp_field == "term_iri"))
 })
 
+test_that("suggest_semantics expands waterbody-style attribute queries for auto-apply compatibility", {
+  dict <- tibble::tibble(
+    dataset_id = "d1",
+    table_id = "t1",
+    column_name = "WATERBODY",
+    column_label = "WATERBODY",
+    column_description = "Waterbody code for the river system",
+    column_role = "attribute",
+    value_type = "string",
+    unit_label = NA_character_,
+    unit_iri = NA_character_,
+    term_iri = NA_character_,
+    property_iri = NA_character_,
+    entity_iri = NA_character_,
+    constraint_iri = NA_character_,
+    method_iri = NA_character_,
+    term_type = NA_character_
+  )
+  codes <- tibble::tibble(
+    dataset_id = "d1",
+    table_id = "t1",
+    column_name = "WATERBODY",
+    code_value = c("FRASER", "THOMPSON"),
+    code_label = c("Fraser River", "Thompson River"),
+    code_description = NA_character_,
+    term_iri = NA_character_
+  )
+
+  calls <- list()
+  fake_search <- function(query, role, ...) {
+    calls[[length(calls) + 1L]] <<- list(query = query, role = role)
+    tibble::tibble(
+      label = "water body",
+      iri = "http://purl.obolibrary.org/obo/ENVO_00000063",
+      source = "ols",
+      ontology = "envo",
+      role = role,
+      match_type = "class",
+      definition = "A body of water."
+    )
+  }
+
+  suggest_semantics(
+    NULL,
+    dict,
+    sources = "ols",
+    max_per_role = 1,
+    search_fn = fake_search,
+    codes = codes
+  )
+
+  call_df <- tibble::as_tibble(purrr::map_dfr(calls, tibble::as_tibble))
+  expect_true(any(call_df$role == "entity" & call_df$query == "water body"))
+})
+
 test_that("apply_semantic_suggestions keeps compatible non-measurement term IRIs and skips bad fits", {
   dict <- tibble::tibble(
     dataset_id = c("d1", "d1", "d1", "d1"),

--- a/tests/testthat/test-term-search.R
+++ b/tests/testthat/test-term-search.R
@@ -335,6 +335,65 @@ test_that("score_and_rank_terms boosts label overlap with query tokens", {
   expect_equal(ranked$label[[1]], "Spawner count")
 })
 
+test_that("score_and_rank_terms demotes generic entity drift and boosts trusted generic entity matches", {
+  vocab <- metasalmon:::`.iadopt_vocab`()
+
+  species_df <- tibble::tibble(
+    label = c("Population", "species", "species"),
+    iri = c(
+      "https://w3id.org/smn/Population",
+      "http://purl.obolibrary.org/obo/APOLLO_SV_00000121",
+      "http://purl.obolibrary.org/obo/NCBITaxon_species"
+    ),
+    source = c("smn", "ols", "ols"),
+    ontology = c("smn", "apollo_sv", "genepio"),
+    role = "entity",
+    match_type = c("definition", "class", "class"),
+    definition = c(
+      "A group of organisms of the same species occupying a defined area that interbreed and share a gene pool.",
+      "Species concept.",
+      "NCBI taxonomy species rank."
+    )
+  )
+
+  species_ranked <- metasalmon:::`.score_and_rank_terms`(species_df, "entity", vocab, "species")
+  expect_equal(species_ranked$iri[[1]], "http://purl.obolibrary.org/obo/NCBITaxon_species")
+  expect_false(identical(species_ranked$iri[[1]], "https://w3id.org/smn/Population"))
+
+  spatial_df <- tibble::tibble(
+    label = c("Body shape", "Escapement", "water body"),
+    iri = c(
+      "https://w3id.org/smn/BodyShape",
+      "https://w3id.org/smn/Escapement",
+      "http://purl.obolibrary.org/obo/ENVO_00000063"
+    ),
+    source = c("smn", "smn", "ols"),
+    ontology = c("smn", "smn", "envo"),
+    role = "entity",
+    match_type = c("class", "class", "class"),
+    definition = c("Fish body shape.", "Escapement counts.", "A body of water.")
+  )
+
+  spatial_ranked <- metasalmon:::`.score_and_rank_terms`(spatial_df, "entity", vocab, "water body")
+  expect_equal(spatial_ranked$iri[[1]], "http://purl.obolibrary.org/obo/ENVO_00000063")
+
+  local_exact_df <- tibble::tibble(
+    label = c("Conservation Unit", "watershed"),
+    iri = c(
+      "https://w3id.org/gcdfo/salmon#ConservationUnit",
+      "http://purl.obolibrary.org/obo/ENVO_00000292"
+    ),
+    source = c("gcdfo", "ols"),
+    ontology = c("gcdfo", "envo"),
+    role = "entity",
+    match_type = c("label_exact", "class"),
+    definition = c("A group of fish sufficiently isolated from other groups...", "A watershed.")
+  )
+
+  local_exact_ranked <- metasalmon:::`.score_and_rank_terms`(local_exact_df, "entity", vocab, "conservation unit")
+  expect_equal(local_exact_ranked$iri[[1]], "https://w3id.org/gcdfo/salmon#ConservationUnit")
+})
+
 test_that("score_and_rank_terms boosts I-ADOPT vocab matches for role", {
   vocab <- metasalmon:::`.iadopt_vocab`()
   df <- tibble::tibble(


### PR DESCRIPTION
## Summary
- demote generic entity query drift from local definition-only matches
- boost trusted generic taxon/spatial matches for species and water body searches
- normalize waterbody-style attribute queries and cover the behavior with tests

## Verification
- `Rscript -e 'devtools::test_file("tests/testthat/test-term-search.R")'`
- `Rscript -e 'devtools::test_file("tests/testthat/test-dictionary-helpers.R")'`
- `Rscript /Users/alan/.openclaw/workspace/tmp/metasalmon-semantic-lab-20260319T0417Z/run_eval.R`
- `Rscript /Users/alan/.openclaw/workspace/tmp/metasalmon-semantic-lab-20260319T0417Z/run_cu_retest.R`
- `Rscript -e 'devtools::test()'`

## Evidence
Representative lab reruns now surface:
- `SPECIES` / `species` / `SPECIES_QUALIFIED` → `NCBITaxon_species`
- `AREA` (waterbody context) → `ENVO_00000063` (`water body`)
- `CU_NAME` still holds the in-domain `gcdfo:ConservationUnit` top match
