### PR TITLE
Improve taxon-style suggestions for species-confirmation attributes

### DIFF
--- a/R/semantics-helpers.R
+++ b/R/semantics-helpers.R
@@ -314,6 +314,35 @@ suggest_semantics <- function(df,
 
     clean_query(text)
   }
+  extract_taxon_like_phrase <- function(x) {
+    text <- expand_attribute_tokens(x)
+    if (!nzchar(text)) return("")
+
+    named_patterns <- c(
+      "atlantic salmon",
+      "chinook salmon",
+      "coho salmon",
+      "sockeye salmon",
+      "chum salmon",
+      "pink salmon",
+      "steelhead trout",
+      "rainbow trout",
+      "cutthroat trout",
+      "salmo salar"
+    )
+    for (pattern in named_patterns) {
+      if (grepl(paste0("\\b", pattern, "\\b"), text, perl = TRUE)) {
+        return(pattern)
+      }
+    }
+
+    latin_match <- regmatches(text, regexpr("\\boncorhynchus\\s+[a-z]+\\b", text, perl = TRUE))
+    if (length(latin_match) == 1 && nzchar(latin_match)) {
+      return(latin_match)
+    }
+
+    ""
+  }
   non_measurement_search_role <- function(row, dict) {
     desc_query <- if (is_review_placeholder(row$column_description[[1]])) {
       ""
@@ -326,7 +355,11 @@ suggest_semantics <- function(df,
     if (!nzchar(query_text)) return("variable")
 
     ctx <- table_context(row, dict)
+    taxon_query <- extract_taxon_like_phrase(query_text)
 
+    if (nzchar(taxon_query) && grepl("\\b(confirm|confirmed|identify|identified|species|taxon)\\b", query_text, perl = TRUE)) {
+      return("entity")
+    }
     if (grepl("\\b(method|protocol|procedure|gear|enumeration)\\b", query_text, perl = TRUE)) {
       return("method")
     }
@@ -368,6 +401,8 @@ suggest_semantics <- function(df,
     }
 
     if (identical(search_role, "entity")) {
+      taxon_query <- extract_taxon_like_phrase(all_text)
+      if (nzchar(taxon_query)) return(taxon_query)
       if (grepl("\\bconservation unit\\b", all_text, perl = TRUE)) return("conservation unit")
       if (grepl("\\bspecies\\b|\\btaxon\\b", all_text, perl = TRUE)) return("species")
       if (grepl("\\bpopulation\\b", all_text, perl = TRUE)) return("population")

--- a/R/term_search.R
+++ b/R/term_search.R
@@ -914,6 +914,65 @@ pattern <- paste(tokens, collapse = ".*")
   bonus
 }
 
+.is_specific_taxon_entity_query <- function(query, role = NA_character_) {
+  role <- tolower(trimws(role %||% ""))
+  if (!identical(role, "entity")) {
+    return(FALSE)
+  }
+
+  query_tokens <- .query_tokens(query %||% "")
+  if (length(query_tokens) == 0) {
+    return(FALSE)
+  }
+
+  if (grepl("^[a-z]+\\s+[a-z]+$", tolower(trimws(query %||% "")))) {
+    return(TRUE)
+  }
+
+  taxon_tokens <- c(
+    "salmon", "trout", "char", "steelhead", "atlantic",
+    "chinook", "coho", "sockeye", "chum", "pink", "kokanee",
+    "salmo", "oncorhynchus"
+  )
+  any(query_tokens %in% taxon_tokens) && length(query_tokens) >= 2
+}
+
+.specific_taxon_entity_adjustment <- function(query, label, iri, source, role = NA_character_) {
+  if (!.is_specific_taxon_entity_query(query, role)) {
+    return(0)
+  }
+
+  query_tokens <- .query_tokens(query %||% "")
+  label_tokens <- .query_tokens(label %||% "")
+  coverage <- if (length(query_tokens) == 0) {
+    0
+  } else {
+    length(intersect(query_tokens, label_tokens)) / length(query_tokens)
+  }
+
+  iri <- iri %||% ""
+  source <- tolower(trimws(source %||% ""))
+  label_text <- tolower(trimws(label %||% ""))
+  generic_local_tokens <- c("population", "group", "stock", "unit", "individual", "life", "stage", "stratum", "reporting", "management")
+  is_generic_local <- source %in% c("smn", "gcdfo") && any(label_tokens %in% generic_local_tokens)
+  is_taxon_authority <- grepl("http://purl\\.obolibrary\\.org/obo/NCBITaxon_", iri, ignore.case = TRUE) ||
+    grepl("marinespecies\\.org|gbif\\.org", iri, ignore.case = TRUE)
+
+  bonus <- 0
+
+  if (is_taxon_authority && coverage > 0) {
+    bonus <- bonus + 6
+  }
+  if (grepl(tolower(trimws(query %||% "")), label_text, fixed = TRUE) && is_taxon_authority) {
+    bonus <- bonus + 1.5
+  }
+  if (is_generic_local && coverage < 1) {
+    bonus <- bonus - 4
+  }
+
+  bonus
+}
+
 .local_short_circuit_hit <- function(query, results) {
   if (nrow(results) == 0) {
     return(FALSE)
@@ -1761,6 +1820,12 @@ sources_for_role <- function(role) {
           iri = df$iri[[i]],
           source = df$source[[i]],
           match_type = df$match_type[[i]],
+          role = role_key
+        ) + .specific_taxon_entity_adjustment(
+          query = query,
+          label = df$label[[i]],
+          iri = df$iri[[i]],
+          source = df$source[[i]],
           role = role_key
         )
       }, numeric(1))

--- a/tests/testthat/fixtures/semantic-ranking-fixtures.json
+++ b/tests/testthat/fixtures/semantic-ranking-fixtures.json
@@ -955,5 +955,52 @@
         "backend_score": 2.7
       }
     ]
+  },
+  {
+    "case_id": "specific-taxon-entity-prefers-authoritative-taxon",
+    "query": "atlantic salmon",
+    "role": "entity",
+    "expected": {
+      "top": {
+        "candidate_id": "ncbitaxon-atlantic-salmon",
+        "source": "ols",
+        "iri_contains": "NCBITaxon_8030"
+      }
+    },
+    "candidates": [
+      {
+        "candidate_id": "smn-salmon-population-group",
+        "label": "Salmon population group",
+        "iri": "https://w3id.org/smn/SalmonPopulationGroup",
+        "source": "smn",
+        "ontology": "smn",
+        "role": "entity",
+        "match_type": "class",
+        "definition": "A grouping of salmon populations used for reporting and management.",
+        "backend_score": 3.0
+      },
+      {
+        "candidate_id": "gcdfo-spawner-abundance",
+        "label": "Spawner abundance",
+        "iri": "https://w3id.org/gcdfo/salmon#SpawnerAbundance",
+        "source": "gcdfo",
+        "ontology": "gcdfo",
+        "role": "entity",
+        "match_type": "class",
+        "definition": "Adult salmon abundance metric.",
+        "backend_score": 2.6
+      },
+      {
+        "candidate_id": "ncbitaxon-atlantic-salmon",
+        "label": "atlantic salmon",
+        "iri": "http://purl.obolibrary.org/obo/NCBITaxon_8030",
+        "source": "ols",
+        "ontology": "mro",
+        "role": "entity",
+        "match_type": "class",
+        "definition": "Atlantic salmon taxon.",
+        "backend_score": 0.8
+      }
+    ]
   }
 ]

--- a/tests/testthat/test-dictionary-helpers.R
+++ b/tests/testthat/test-dictionary-helpers.R
@@ -549,6 +549,61 @@ test_that("suggest_semantics uses role-aware search roles for controlled attribu
   expect_true(all(column_suggestions$target_sdp_field == "term_iri"))
 })
 
+test_that("suggest_semantics uses taxon-style entity queries for species confirmation attributes", {
+  dict <- tibble::tibble(
+    dataset_id = "d1",
+    table_id = "t1",
+    column_name = "confirmed_atlantic_salmon",
+    column_label = "Confirmed Atlantic Salmon?",
+    column_description = "Boolean confirmation that the capture was Atlantic salmon.",
+    column_role = "attribute",
+    value_type = "boolean",
+    unit_label = NA_character_,
+    unit_iri = NA_character_,
+    term_iri = NA_character_,
+    property_iri = NA_character_,
+    entity_iri = NA_character_,
+    constraint_iri = NA_character_,
+    method_iri = NA_character_,
+    term_type = NA_character_
+  )
+  codes <- tibble::tibble(
+    dataset_id = "d1",
+    table_id = "t1",
+    column_name = "confirmed_atlantic_salmon",
+    code_value = c("Yes", "No"),
+    code_label = c("Yes", "No"),
+    code_description = NA_character_,
+    term_iri = NA_character_
+  )
+
+  calls <- list()
+  fake_search <- function(query, role, ...) {
+    calls[[length(calls) + 1L]] <<- list(query = query, role = role)
+    tibble::tibble(
+      label = "Atlantic salmon",
+      iri = "http://purl.obolibrary.org/obo/NCBITaxon_8030",
+      source = "ols",
+      ontology = "mro",
+      role = role,
+      match_type = "class",
+      definition = "Atlantic salmon taxon."
+    )
+  }
+
+  suggest_semantics(
+    NULL,
+    dict,
+    sources = "ols",
+    max_per_role = 1,
+    search_fn = fake_search,
+    codes = codes
+  )
+
+  call_df <- tibble::as_tibble(purrr::map_dfr(calls, tibble::as_tibble))
+  expect_true(any(call_df$role == "entity" & call_df$query == "atlantic salmon"))
+})
+
 test_that("suggest_semantics expands waterbody-style attribute queries for auto-apply compatibility", {
   dict <- tibble::tibble(
     dataset_id = "d1",


### PR DESCRIPTION
## Summary
- search taxon-like phrases from non-measurement attribute labels/descriptions as entity queries
- boost authoritative taxon IRIs above broad salmon-group concepts for specific taxon phrases
- add fixture and dictionary-helper coverage for the Atlantic Salmon confirmation case

## Verification
- Rscript -e 'devtools::test_file("tests/testthat/test-dictionary-helpers.R"); devtools::test_file("tests/testthat/test-term-search.R")'\n- Rscript -e 'devtools::load_all(".", quiet=TRUE); fp <- testthat::test_path("fixtures", "semantic-ranking-fixtures.json"); print(benchmark_term_ranking_fixtures(fixture_path = fp)$summary)'\n- real create_sdp retest on Atlantic Salmon captured BC\n- real create_sdp control on CWT release data\n- Rscript -e 'devtools::test()'