### PR TITLE
Refine attribute semantic query roles

### DIFF
--- a/R/semantics-helpers.R
+++ b/R/semantics-helpers.R
@@ -363,10 +363,13 @@ suggest_semantics <- function(df,
     if (grepl("\\b(method|protocol|procedure|gear|enumeration)\\b", query_text, perl = TRUE)) {
       return("method")
     }
+    if (grepl("\\b(watershed|waterbody|river|stream|location|site|area|conservation unit|management unit)\\b", query_text, perl = TRUE)) {
+      return("entity")
+    }
     if (grepl("\\b(stage|classification|class|type|status|context|origin|accuracy|precision|reliability|index)\\b", query_text, perl = TRUE)) {
       return("constraint")
     }
-    if (grepl("\\b(species|taxon|population|stock|watershed|waterbody|river|stream|location|site|area|conservation unit)\\b", query_text, perl = TRUE)) {
+    if (grepl("\\b(species|taxon|population|stock)\\b", query_text, perl = TRUE)) {
       return("entity")
     }
 
@@ -389,6 +392,7 @@ suggest_semantics <- function(df,
     if (identical(search_role, "method")) {
       if (grepl("\\bestimate\\b", all_text, perl = TRUE) && grepl("\\bmethod\\b", all_text, perl = TRUE)) return("estimate method")
       if (grepl("\\bcount(ing)?\\b", all_text, perl = TRUE) && grepl("\\bmethod\\b", all_text, perl = TRUE)) return("counting method")
+      if (grepl("\\bcatch\\b", all_text, perl = TRUE) && grepl("\\bmethod\\b", all_text, perl = TRUE)) return("capture method")
       return(base_query)
     }
 
@@ -404,6 +408,8 @@ suggest_semantics <- function(df,
       taxon_query <- extract_taxon_like_phrase(all_text)
       if (nzchar(taxon_query)) return(taxon_query)
       if (grepl("\\bconservation unit\\b", all_text, perl = TRUE)) return("conservation unit")
+      if (grepl("\\baquaculture management unit\\b", all_text, perl = TRUE)) return("aquaculture management unit")
+      if (grepl("\\bmanagement unit\\b", all_text, perl = TRUE)) return("management unit")
       if (grepl("\\bspecies\\b|\\btaxon\\b", all_text, perl = TRUE)) return("species")
       if (grepl("\\bpopulation\\b", all_text, perl = TRUE)) return("population")
       if (grepl("\\bwatershed\\b", all_text, perl = TRUE)) return("watershed")

--- a/tests/testthat/test-dictionary-helpers.R
+++ b/tests/testthat/test-dictionary-helpers.R
@@ -549,6 +549,69 @@ test_that("suggest_semantics uses role-aware search roles for controlled attribu
   expect_true(all(column_suggestions$target_sdp_field == "term_iri"))
 })
 
+test_that("suggest_semantics keeps site and management-unit attributes on entity-style queries and rewrites catch methods", {
+  dict <- tibble::tibble(
+    dataset_id = c("d1", "d1", "d1"),
+    table_id = c("t1", "t1", "t1"),
+    column_name = c("site_type", "aquaculture_management_unit", "catch_method"),
+    column_label = c("Site Type", "Aquaculture Management Unit", "Catch Method"),
+    column_description = c(
+      "Type of sampling site",
+      "Aquaculture management unit name",
+      "Method used to catch the fish"
+    ),
+    column_role = c("attribute", "attribute", "attribute"),
+    value_type = c("string", "string", "string"),
+    unit_label = c(NA_character_, NA_character_, NA_character_),
+    unit_iri = c(NA_character_, NA_character_, NA_character_),
+    term_iri = c(NA_character_, NA_character_, NA_character_),
+    property_iri = c(NA_character_, NA_character_, NA_character_),
+    entity_iri = c(NA_character_, NA_character_, NA_character_),
+    constraint_iri = c(NA_character_, NA_character_, NA_character_),
+    method_iri = c(NA_character_, NA_character_, NA_character_),
+    term_type = c(NA_character_, NA_character_, NA_character_)
+  )
+  codes <- tibble::tibble(
+    dataset_id = c("d1", "d1", "d1"),
+    table_id = c("t1", "t1", "t1"),
+    column_name = c("site_type", "aquaculture_management_unit", "catch_method"),
+    code_value = c("OPEN", "CLAYOQUOT", "TROLL"),
+    code_label = c("Open", "Clayoquot Sound", "Trolling"),
+    code_description = c("Open site", "Management unit", "Fishing capture method"),
+    vocabulary_iri = c(NA_character_, NA_character_, NA_character_),
+    term_iri = c(NA_character_, NA_character_, NA_character_),
+    term_type = c(NA_character_, NA_character_, NA_character_)
+  )
+
+  calls <- list()
+  fake_search <- function(query, role, sources) {
+    calls[[length(calls) + 1]] <<- list(query = query, role = role)
+    tibble::tibble(
+      label = paste("candidate", role),
+      iri = paste0("https://example.org/", role, "/", gsub("\\s+", "-", tolower(query))),
+      source = "ols",
+      ontology = "demo",
+      role = role,
+      match_type = "label_partial",
+      definition = ""
+    )
+  }
+
+  suggest_semantics(
+    NULL,
+    dict,
+    sources = "ols",
+    max_per_role = 1,
+    search_fn = fake_search,
+    codes = codes
+  )
+
+  call_df <- tibble::as_tibble(purrr::map_dfr(calls, tibble::as_tibble))
+  expect_true(any(call_df$role == "entity" & call_df$query == "site"))
+  expect_true(any(call_df$role == "entity" & call_df$query == "aquaculture management unit"))
+  expect_true(any(call_df$role == "method" & call_df$query == "capture method"))
+})
+
 test_that("suggest_semantics uses taxon-style entity queries for species confirmation attributes", {
   dict <- tibble::tibble(
     dataset_id = "d1",


### PR DESCRIPTION
## Summary
- route site/location/management-unit style attribute labels through entity-style query planning before the generic type/status fallback
- rewrite `Catch Method` style labels to the bounded `capture method` query instead of a generic variable query
- add deterministic dictionary-helper regressions for Miramichi site type, carcass aquaculture management unit, and Atlantic catch method planning

## Verification
- `Rscript -e 'devtools::test_file("tests/testthat/test-dictionary-helpers.R")'`
- `Rscript -e 'devtools::test()'`
- representative real-dataset semantic checks on Miramichi `site_type__type_de_site`, carcass `Aquaculture Management Unit`, and Atlantic `Catch Method`

## Notes
- Keeps auto-apply conservative; this is query planning only.
- Leaves the remaining shallow ranking cleanup (`attribute-negative-control-ranking`) for a follow-up patch.
