### PR TITLE
Seed location-like attribute term suggestions without low-cardinality codes

### DIFF
--- a/R/semantics-helpers.R
+++ b/R/semantics-helpers.R
@@ -469,6 +469,25 @@ suggest_semantics <- function(df,
     }
     any(keep)
   }
+  has_location_like_column_signal <- function(row, dict) {
+    if (!identical(non_measurement_search_role(row, dict), "entity")) {
+      return(FALSE)
+    }
+
+    desc_query <- if (is_review_placeholder(row$column_description[[1]])) {
+      ""
+    } else {
+      strip_review_placeholder(row$column_description[[1]])
+    }
+    label_query <- strip_review_placeholder(row$column_label[[1]])
+    name_query <- strip_review_placeholder(row$column_name[[1]])
+    query_text <- expand_attribute_tokens(paste(desc_query, label_query, name_query, collapse = " "))
+    if (!nzchar(query_text)) {
+      return(FALSE)
+    }
+
+    grepl("\\b(watershed|waterbody|river|stream|location|site)\\b", query_text, perl = TRUE)
+  }
   non_measurement_roles <- function(row, codes, dict) {
     role <- tolower(as.character(row$column_role[[1]] %||% ""))
     if (!nzchar(role) || role %in% c("identifier", "temporal")) return(character())
@@ -476,7 +495,10 @@ suggest_semantics <- function(df,
 
     term_missing <- "term_iri" %in% names(row) && is_missing(row$term_iri[[1]])
     if (!term_missing) return(character())
-    if (!has_low_card_codes(row, codes)) return(character())
+
+    has_codes <- has_low_card_codes(row, codes)
+    location_fallback <- has_location_like_column_signal(row, dict)
+    if (!has_codes && !location_fallback) return(character())
 
     if (role %in% c("categorical", "attribute")) {
       return(c(term_iri = non_measurement_search_role(row, dict)))

--- a/tests/testthat/test-dictionary-helpers.R
+++ b/tests/testthat/test-dictionary-helpers.R
@@ -612,6 +612,66 @@ test_that("suggest_semantics keeps site and management-unit attributes on entity
   expect_true(any(call_df$role == "method" & call_df$query == "capture method"))
 })
 
+test_that("suggest_semantics seeds location-like attribute term suggestions without low-cardinality codes", {
+  dict <- tibble::tibble(
+    dataset_id = c("d1", "d1", "d1", "d1"),
+    table_id = c("t1", "t1", "t1", "t1"),
+    column_name = c("WATERSHED_CDE", "release_location_code", "SYSTEM_SITE", "SPECIES_QUALIFIED"),
+    column_label = c("WATERSHED_CDE", "release_location_code", "SYSTEM_SITE", "SPECIES_QUALIFIED"),
+    column_description = c(
+      "Watershed code",
+      "Release location code",
+      "System site label",
+      "Qualified species label"
+    ),
+    column_role = c("attribute", "attribute", "attribute", "attribute"),
+    value_type = c("string", "string", "string", "string"),
+    unit_label = c(NA_character_, NA_character_, NA_character_, NA_character_),
+    unit_iri = c(NA_character_, NA_character_, NA_character_, NA_character_),
+    term_iri = c(NA_character_, NA_character_, NA_character_, NA_character_),
+    property_iri = c(NA_character_, NA_character_, NA_character_, NA_character_),
+    entity_iri = c(NA_character_, NA_character_, NA_character_, NA_character_),
+    constraint_iri = c(NA_character_, NA_character_, NA_character_, NA_character_),
+    method_iri = c(NA_character_, NA_character_, NA_character_, NA_character_),
+    term_type = c(NA_character_, NA_character_, NA_character_, NA_character_)
+  )
+  codes <- tibble::tibble()
+
+  calls <- list()
+  fake_search <- function(query, role, sources) {
+    calls[[length(calls) + 1]] <<- list(query = query, role = role)
+    tibble::tibble(
+      label = paste("candidate", role),
+      iri = paste0("https://example.org/", role, "/", gsub("\\s+", "-", tolower(query))),
+      source = "ols",
+      ontology = "demo",
+      role = role,
+      match_type = "label_partial",
+      definition = ""
+    )
+  }
+
+  res <- suggest_semantics(
+    NULL,
+    dict,
+    sources = "ols",
+    max_per_role = 1,
+    search_fn = fake_search,
+    codes = codes
+  )
+
+  suggestions <- attr(res, "semantic_suggestions")
+  column_suggestions <- suggestions[suggestions$target_scope == "column" & suggestions$target_sdp_field == "term_iri", , drop = FALSE]
+  call_df <- tibble::as_tibble(purrr::map_dfr(calls, tibble::as_tibble))
+
+  expect_true(any(column_suggestions$column_name == "WATERSHED_CDE"))
+  expect_true(any(column_suggestions$column_name == "release_location_code"))
+  expect_true(any(column_suggestions$column_name == "SYSTEM_SITE"))
+  expect_false(any(column_suggestions$column_name == "SPECIES_QUALIFIED"))
+  expect_true(any(call_df$role == "entity" & call_df$query == "watershed"))
+  expect_true(any(call_df$role == "entity" & call_df$query == "site"))
+})
+
 test_that("suggest_semantics uses taxon-style entity queries for species confirmation attributes", {
   dict <- tibble::tibble(
     dataset_id = "d1",


### PR DESCRIPTION
## Summary
- allow entity-like location attributes to seed review-only `term_iri` suggestions even when code tables are absent because the column is high-cardinality
- keep the fallback narrow to location-style signals (`watershed`, `waterbody`, `river`, `stream`, `location`, `site`) instead of broadening all entity-like attributes
- cover the new path with targeted tests so species-style attributes without codes still stay out

## Verification
- `Rscript -e "devtools::load_all('.'); testthat::test_file('tests/testthat/test-dictionary-helpers.R')"`
- `Rscript -e "devtools::test()"`
- representative dataset retest after patch:
  - NuSEDS `WATERSHED_CDE` now gets a `watershed` term suggestion
  - CWT `release_location_code` / `stock_location_code` now get `site` term suggestions
  - CU lookup `SYSTEM_SITE` now gets a `site` term suggestion
