### PR TITLE
Recognize wide numeric and percent metrics

### DIFF
--- a/R/dictionary-helpers.R
+++ b/R/dictionary-helpers.R
@@ -546,6 +546,67 @@ infer_value_type <- function(col) {
   all(!is.na(years) & years >= 1800 & years <= 2500)
 }
 
+.ms_values_look_numericish <- function(col, min_fraction = 0.8) {
+  if (inherits(col, c("integer", "numeric"))) {
+    return(TRUE)
+  }
+
+  values <- as.character(col)
+  values <- trimws(values[!is.na(values)])
+  values <- values[nzchar(values)]
+  if (length(values) == 0) {
+    return(FALSE)
+  }
+
+  lowered <- tolower(values)
+  missing_like <- lowered %in% c("na", "n/a", "nd", "null", "nil", "missing")
+  values <- values[!missing_like]
+  if (length(values) == 0) {
+    return(FALSE)
+  }
+
+  normalized <- gsub(",", "", values, fixed = TRUE)
+  normalized <- gsub("%", "", normalized, fixed = TRUE)
+  normalized <- gsub("^[<>]=?\\s*", "", normalized)
+  normalized <- trimws(normalized)
+  parsed <- suppressWarnings(as.numeric(normalized))
+  mean(!is.na(parsed)) >= min_fraction
+}
+
+.ms_name_has_measurement_hint <- function(name_lower, name_tokens) {
+  measurement_tokens <- c(
+    "count", "counts", "total", "totals", "number", "numbers", "amount", "quantity",
+    "measure", "measurement", "measurements", "abundance", "abundances", "spawner", "spawners",
+    "recruit", "recruits", "escapement", "escapements", "biomass", "density", "densities",
+    "rate", "rates", "ratio", "ratios", "proportion", "proportions", "percent", "percentage",
+    "length", "lengths", "weight", "weights", "temperature", "temperatures", "temp",
+    "depth", "depths", "width", "widths", "height", "heights", "level", "levels",
+    "discharge", "flow", "flows", "mortality"
+  )
+  has_token_hint <- any(name_tokens %in% measurement_tokens)
+  has_regex_hint <- grepl(
+    "count|total|number|amount|quantity|measure|temp|temperature|depth|width|height|level|discharge|flow|mortality",
+    name_lower
+  )
+  has_unit_hint <- grepl(
+    "\\([^)]*(%|‰|°c|deg\\s*c|cms|m3/s|mm|cm|\\bm\\b|kg|g|mg/l|ug/l)[^)]*\\)",
+    name_lower,
+    perl = TRUE
+  )
+
+  has_token_hint || has_regex_hint || has_unit_hint
+}
+
+.ms_name_looks_identifierish <- function(name_tokens) {
+  number_tokens <- c("number", "numbers", "no", "num")
+  identifier_context_tokens <- c(
+    "reference", "facility", "station", "site", "sample", "licence", "license",
+    "permit", "record", "report", "release", "tag"
+  )
+
+  any(name_tokens %in% number_tokens) && any(name_tokens %in% identifier_context_tokens)
+}
+
 #' Infer column role from name and data
 #'
 #' @param col_name Column name
@@ -563,7 +624,7 @@ infer_column_role <- function(col_name, col) {
   if (grepl("^key$|_key$|^key_", name_lower)) {
     return("identifier")
   }
-  if (any(name_tokens %in% c("id", "key"))) {
+  if (any(name_tokens %in% c("id", "key")) || .ms_name_looks_identifierish(name_tokens)) {
     return("identifier")
   }
 
@@ -591,15 +652,9 @@ infer_column_role <- function(col_name, col) {
     return("attribute")
   }
 
-  # Check for measurement/quantity patterns
-  measurement_tokens <- c(
-    "count", "counts", "total", "totals", "number", "numbers", "amount", "quantity",
-    "measure", "measurement", "measurements", "abundance", "abundances", "spawner", "spawners",
-    "recruit", "recruits", "escapement", "escapements", "biomass", "density", "densities",
-    "rate", "rates", "ratio", "ratios", "proportion", "proportions", "percent", "percentage",
-    "length", "lengths", "weight", "weights", "temperature", "temperatures"
-  )
-  if (grepl("count|total|number|amount|quantity|measure", name_lower) || any(name_tokens %in% measurement_tokens)) {
+  # Check for measurement/quantity patterns. Wide real-world tables often hide
+  # measurements behind unit-bearing headers or percent-like strings.
+  if (.ms_name_has_measurement_hint(name_lower, name_tokens) && .ms_values_look_numericish(col)) {
     return("measurement")
   }
 

--- a/tests/testthat/test-dictionary-helpers.R
+++ b/tests/testthat/test-dictionary-helpers.R
@@ -89,6 +89,32 @@ test_that("infer_dictionary keeps method-like count fields out of measurement ro
   expect_equal(dict$column_role[dict$column_name == "avg_weight"], "measurement")
 })
 
+test_that("infer_dictionary recognizes wide numeric and percent metrics without promoting QA or reference fields", {
+  df <- tibble::tibble(
+    `Facility Reference Number` = c(1001, 1002),
+    `Environmental (%/month)` = c("0.00%", "4.56%"),
+    `Water Level / Niveau d'eau (m)` = c(1.2, 1.4),
+    `Discharge / Débit (cms)` = c(10.5, 11.1),
+    water_temp_c__temp_eau_c = c(12.3, 12.8),
+    width_middle = c(4.2, 4.5),
+    depth_1_lower = c(0.5, 0.7),
+    `Grade...4` = c(10, 10),
+    `QA/QC...6` = c("Approved", "Approved")
+  )
+
+  dict <- infer_dictionary(df, dataset_id = "test-1", table_id = "table-1")
+
+  expect_equal(dict$column_role[dict$column_name == "Facility Reference Number"], "identifier")
+  expect_equal(dict$column_role[dict$column_name == "Environmental (%/month)"], "measurement")
+  expect_equal(dict$column_role[dict$column_name == "Water Level / Niveau d'eau (m)"], "measurement")
+  expect_equal(dict$column_role[dict$column_name == "Discharge / Débit (cms)"], "measurement")
+  expect_equal(dict$column_role[dict$column_name == "water_temp_c__temp_eau_c"], "measurement")
+  expect_equal(dict$column_role[dict$column_name == "width_middle"], "measurement")
+  expect_equal(dict$column_role[dict$column_name == "depth_1_lower"], "measurement")
+  expect_equal(dict$column_role[dict$column_name == "Grade...4"], "attribute")
+  expect_equal(dict$column_role[dict$column_name == "QA/QC...6"], "attribute")
+})
+
 test_that("infer_dictionary can seed semantic suggestions", {
   fake_suggest <- function(df, dict, sources = c("ols", "nvs"), max_per_role = 1, include_dwc = FALSE,
                            codes = NULL, table_meta = NULL, dataset_meta = NULL, ...) {


### PR DESCRIPTION
## Summary
- recognize wide numeric and percent-like metric columns as measurements during dictionary role inference
- keep identifier-style `reference/facility/... number` fields and QA/status columns out of the measurement bucket
- add regressions for hydrometric, carcass, and Miramichi-style headers that drove the lab recommendation

## Verification
- `Rscript -e 'devtools::test_file("tests/testthat/test-dictionary-helpers.R")'`
- `Rscript -e "devtools::test()"`
