### PR TITLE
Guard broad physical measurement auto-apply

### DIFF
--- a/R/package-helpers.R
+++ b/R/package-helpers.R
@@ -1186,6 +1186,107 @@ read_salmon_datapackage <- function(path) {
   length(intersect(query_tokens, label_tokens)) > 0
 }
 
+.ms_measurement_query_looks_physical <- function(...) {
+  text <- paste(unlist(list(...)), collapse = " ")
+  text <- tolower(text)
+  grepl(
+    "\\b(water|level|discharge|flow|temperature|temp|rain|rainfall|snow|snowfall|precip|gust|wind|speed|depth|width|height|meter|metre|celsius)\\b",
+    text,
+    perl = TRUE
+  )
+}
+
+.ms_normalize_measurement_unit_text <- function(x) {
+  text <- tolower(.ms_scalar_text(x))
+  text <- gsub("â", "", text, fixed = TRUE)
+  text <- gsub("°", " degree ", text, fixed = TRUE)
+  text <- gsub("³", "3", text, fixed = TRUE)
+  text <- gsub("[^a-z0-9/ ]+", " ", text)
+  text <- trimws(gsub("\\s+", " ", text))
+  if (!nzchar(text)) {
+    return("")
+  }
+
+  if (grepl("^(cubic meter per second|cubic metre per second|m3/s|cms|cumec|cumecs)$", text)) return("cubic meter per second")
+  if (grepl("^(degree celsius|degrees celsius|deg c|celsius)$", text)) return("degree celsius")
+  if (grepl("^(kilometer per hour|kilometre per hour|km/h|kph)$", text)) return("kilometer per hour")
+  if (grepl("^millimet(er|re)s?$", text)) return("millimeter")
+  if (grepl("^centimet(er|re)s?$", text)) return("centimeter")
+  if (grepl("^met(er|re)s?$", text)) return("meter")
+
+  text
+}
+
+.ms_measurement_suggestion_is_compatible <- function(suggestion, dict_row) {
+  role <- tolower(as.character(dict_row$column_role[[1]] %||% ""))
+  if (!identical(role, "measurement")) {
+    return(TRUE)
+  }
+
+  query_text <- paste(
+    if ("search_query" %in% names(suggestion)) .ms_scalar_text(suggestion$search_query) else "",
+    if ("target_label" %in% names(suggestion)) .ms_scalar_text(suggestion$target_label) else "",
+    if ("column_label" %in% names(suggestion)) .ms_scalar_text(suggestion$column_label) else "",
+    if ("column_name" %in% names(suggestion)) .ms_scalar_text(suggestion$column_name) else ""
+  )
+  if (!.ms_measurement_query_looks_physical(query_text)) {
+    return(TRUE)
+  }
+
+  label <- .ms_scalar_text(suggestion$label)
+  if (!nzchar(label) || .ms_is_review_placeholder(label)) {
+    return(FALSE)
+  }
+
+  target_field <- if ("target_sdp_field" %in% names(suggestion)) {
+    .ms_scalar_text(suggestion$target_sdp_field)
+  } else {
+    ""
+  }
+
+  match_type <- if ("match_type" %in% names(suggestion)) {
+    tolower(.ms_scalar_text(suggestion$match_type))
+  } else {
+    ""
+  }
+
+  if (identical(target_field, "unit_iri")) {
+    query_unit <- .ms_normalize_measurement_unit_text(
+      if ("search_query" %in% names(suggestion)) suggestion$search_query else ""
+    )
+    label_unit <- .ms_normalize_measurement_unit_text(label)
+    if (!nzchar(query_unit) || !nzchar(label_unit) || !identical(query_unit, label_unit)) {
+      return(FALSE)
+    }
+    if ("score" %in% names(suggestion)) {
+      score <- suppressWarnings(as.numeric(suggestion$score[[1]]))
+      if (!is.na(score) && score < 0.75) {
+        return(FALSE)
+      }
+    }
+    return(TRUE)
+  }
+
+  if (nzchar(match_type) && !grepl("label|unit", match_type)) {
+    return(FALSE)
+  }
+
+  if ("score" %in% names(suggestion)) {
+    score <- suppressWarnings(as.numeric(suggestion$score[[1]]))
+    if (!is.na(score) && score < 0.75) {
+      return(FALSE)
+    }
+  }
+
+  query_tokens <- unique(.ms_non_measurement_target_tokens(query_text))
+  label_tokens <- unique(.ms_non_measurement_target_tokens(label))
+  if (length(query_tokens) == 0 || length(label_tokens) == 0) {
+    return(FALSE)
+  }
+
+  length(intersect(query_tokens, label_tokens)) > 0
+}
+
 .ms_filter_auto_apply_suggestions <- function(dict, suggestions) {
   if (is.null(suggestions) || nrow(suggestions) == 0) {
     return(suggestions)
@@ -1197,9 +1298,6 @@ read_salmon_datapackage <- function(path) {
       .ms_scalar_text(suggestion$target_sdp_field)
     } else {
       ""
-    }
-    if (nzchar(target_field) && !identical(target_field, "term_iri")) {
-      return(TRUE)
     }
     if (!nzchar(target_field)) {
       return(TRUE)
@@ -1225,6 +1323,9 @@ read_salmon_datapackage <- function(path) {
       role <- tolower(as.character(dict_row$column_role[[1]] %||% ""))
       if (role %in% c("identifier", "temporal")) {
         return(FALSE)
+      }
+      if (identical(role, "measurement")) {
+        return(.ms_measurement_suggestion_is_compatible(suggestion, dict_row))
       }
       .ms_non_measurement_suggestion_is_compatible(suggestion, dict_row)
     }, logical(1)))

--- a/R/semantics-helpers.R
+++ b/R/semantics-helpers.R
@@ -204,6 +204,77 @@ suggest_semantics <- function(df,
     if (length(candidates) == 0) return(FALSE)
     any(grepl(pattern, candidates, ignore.case = TRUE))
   }
+  normalize_measurement_unit_query <- function(x) {
+    text <- tolower(as.character(x %||% ""))
+    text[is.na(text)] <- ""
+    text <- gsub("â", "", text, fixed = TRUE)
+    text <- gsub("°", " degree ", text, fixed = TRUE)
+    text <- gsub("³", "3", text, fixed = TRUE)
+    text <- clean_query(text)
+    text <- gsub("[^a-z0-9/ ]+", " ", text)
+    text <- clean_query(text)
+    if (!nzchar(text)) return("")
+
+    if (grepl("\\b(degree\\s*c|deg\\s*c|celsius)\\b", text)) return("degree celsius")
+    if (grepl("^(cms|cumec|cumecs|m3/s|m\\^3/s|m3 s)$", text)) return("cubic meter per second")
+    if (grepl("^(km/h|km h|kph)$", text)) return("kilometer per hour")
+    if (grepl("^(mm|millimet(er|re)s?)$", text)) return("millimeter")
+    if (grepl("^(cm|centimet(er|re)s?)$", text)) return("centimeter")
+    if (grepl("^(m|met(er|re)s?)$", text)) return("meter")
+    if (grepl("^(g|gram(me)?s?)$", text)) return("gram")
+    if (grepl("^(kg|kilogram(me)?s?)$", text)) return("kilogram")
+
+    ""
+  }
+  extract_measurement_header_unit <- function(...) {
+    texts <- unlist(list(...), use.names = FALSE)
+    texts <- as.character(texts)
+    texts <- texts[!is.na(texts) & nzchar(trimws(texts))]
+    if (length(texts) == 0) return("")
+
+    for (text in texts) {
+      matches <- gregexpr("\\(([^)]{1,20})\\)", text, perl = TRUE)
+      pieces <- regmatches(text, matches)[[1]]
+      if (length(pieces) == 0) next
+      pieces <- trimws(gsub("^\\(|\\)$", "", pieces))
+      pieces <- pieces[nzchar(pieces)]
+      if (length(pieces) == 0) next
+      normalized <- normalize_measurement_unit_query(utils::tail(pieces, 1))
+      if (nzchar(normalized)) {
+        return(normalized)
+      }
+    }
+
+    ""
+  }
+  normalize_measurement_header_query <- function(x) {
+    text <- clean_query(x)
+    if (!nzchar(text)) return("")
+
+    text <- gsub("\\([^)]*\\)", " ", text)
+    if (grepl("\\s/\\s", text)) {
+      text <- strsplit(text, "\\s/\\s", perl = TRUE)[[1]][1]
+    }
+    text <- tolower(clean_query(text))
+    replacements <- c(
+      "\\btemp\\b" = "temperature",
+      "\\bspd\\b" = "speed",
+      "\\bdir\\b" = "direction",
+      "\\bmax\\b" = "maximum",
+      "\\bmin\\b" = "minimum",
+      "\\bgrnd\\b" = "ground"
+    )
+    for (pattern in names(replacements)) {
+      text <- gsub(pattern, replacements[[pattern]], text, perl = TRUE)
+    }
+
+    if (grepl("\\btotal rain\\b", text)) return("rainfall")
+    if (grepl("\\btotal snow\\b", text)) return("snowfall")
+    if (grepl("\\bwater level\\b", text)) return("water level")
+    if (grepl("\\bdischarge\\b", text)) return("discharge")
+
+    clean_query(text)
+  }
   is_count_like_measurement <- function(row, base_query) {
     value_type <- tolower(as.character(row$value_type[[1]] %||% ""))
     text <- tolower(clean_query(paste(
@@ -231,7 +302,11 @@ suggest_semantics <- function(df,
     }
     label_query <- strip_review_placeholder(row$column_label[[1]])
     name_query <- strip_review_placeholder(row$column_name[[1]])
-    base_query <- clean_query(first_non_empty(list(desc_query, label_query, name_query)))
+    base_query <- if (nzchar(desc_query)) {
+      clean_query(desc_query)
+    } else {
+      normalize_measurement_header_query(first_non_empty(list(label_query, name_query)))
+    }
     if (!nzchar(base_query)) return("")
 
     base_lower <- tolower(base_query)
@@ -239,6 +314,9 @@ suggest_semantics <- function(df,
 
     if (identical(role_name, "unit")) {
       unit_query <- strip_review_placeholder(row$unit_label[[1]])
+      if (!nzchar(unit_query)) {
+        unit_query <- extract_measurement_header_unit(row$column_label[[1]], row$column_name[[1]])
+      }
       if (nzchar(unit_query)) {
         return(unit_query)
       }

--- a/tests/testthat/test-dictionary-helpers.R
+++ b/tests/testthat/test-dictionary-helpers.R
@@ -388,6 +388,49 @@ test_that("suggest_semantics uses count-like measurement queries for adult spawn
   expect_true(any(call_df$role == "unit" & call_df$query == "count"))
 })
 
+test_that("suggest_semantics normalizes wide measurement headers and header units", {
+  dict <- tibble::tibble(
+    dataset_id = c("d1", "d1", "d1"),
+    table_id = c("t1", "t1", "t1"),
+    column_name = c("Water Level / Niveau d'eau (m)", "Max Temp (°C)", "Discharge / Débit (cms)"),
+    column_label = c("Water Level / Niveau d'eau (m)", "Max Temp (°C)", "Discharge / Débit (cms)"),
+    column_description = c(NA_character_, NA_character_, NA_character_),
+    column_role = c("measurement", "measurement", "measurement"),
+    value_type = c("number", "number", "number"),
+    unit_label = c(NA_character_, NA_character_, NA_character_),
+    unit_iri = c(NA_character_, NA_character_, NA_character_),
+    term_iri = c(NA_character_, NA_character_, NA_character_),
+    property_iri = c(NA_character_, NA_character_, NA_character_),
+    entity_iri = c(NA_character_, NA_character_, NA_character_),
+    constraint_iri = c(NA_character_, NA_character_, NA_character_),
+    method_iri = c(NA_character_, NA_character_, NA_character_)
+  )
+
+  calls <- list()
+  fake_search <- function(query, role, sources) {
+    calls[[length(calls) + 1]] <<- list(query = query, role = role)
+    tibble::tibble(
+      label = paste("candidate", role),
+      iri = paste0("https://example.org/", role),
+      source = "ols",
+      ontology = "demo",
+      role = role,
+      match_type = "label_partial",
+      definition = ""
+    )
+  }
+
+  suggest_semantics(NULL, dict, sources = "ols", max_per_role = 1, search_fn = fake_search)
+
+  call_df <- tibble::as_tibble(purrr::map_dfr(calls, tibble::as_tibble))
+  expect_true(any(call_df$role == "variable" & call_df$query == "water level"))
+  expect_true(any(call_df$role == "unit" & call_df$query == "meter"))
+  expect_true(any(call_df$role == "variable" & call_df$query == "maximum temperature"))
+  expect_true(any(call_df$role == "unit" & call_df$query == "degree celsius"))
+  expect_true(any(call_df$role == "variable" & call_df$query == "discharge"))
+  expect_true(any(call_df$role == "unit" & call_df$query == "cubic meter per second"))
+})
+
 test_that("suggest_semantics ignores review placeholders when building table observation-unit queries", {
   dict <- tibble::tibble(
     dataset_id = "d1",

--- a/tests/testthat/test-package-helpers.R
+++ b/tests/testthat/test-package-helpers.R
@@ -475,6 +475,77 @@ test_that("create_sdp filters bad non-measurement term IRIs before auto-apply", 
   expect_equal(dict_written$term_iri[dict_written$column_name == "WATERBODY"], "https://example.org/waterbody")
 })
 
+test_that("create_sdp keeps broad physical measurement matches review-only but still applies unit hits", {
+  resources <- list(
+    hydro = tibble::tibble(
+      water_level = c(1.2, 1.3),
+      spawner_count = c(10L, 20L)
+    )
+  )
+
+  fake_suggest <- function(df, dict, sources = c("smn", "gcdfo", "ols", "nvs"),
+                           include_dwc = FALSE, max_per_role = 3,
+                           search_fn = find_terms, codes = NULL,
+                           table_meta = NULL, dataset_meta = NULL) {
+    attr(dict, "semantic_suggestions") <- tibble::tibble(
+      dataset_id = c(rep("hydro-demo", 5), rep("hydro-demo", 2)),
+      table_id = c(rep("hydro", 5), rep("hydro", 2)),
+      column_name = c(rep("water_level", 5), rep("spawner_count", 2)),
+      dictionary_role = c("variable", "property", "entity", "method", "unit", "variable", "property"),
+      target_scope = "column",
+      target_sdp_file = "column_dictionary.csv",
+      target_sdp_field = c("term_iri", "property_iri", "entity_iri", "method_iri", "unit_iri", "term_iri", "property_iri"),
+      search_query = c("water level", "water level", "water level", "water level", "meter", "adult spawner count", "count"),
+      column_label = c(rep("Water Level (m)", 5), rep("Spawner Count", 2)),
+      label = c("Escapement", "Mainstem phase", "Population", "uses observation procedure", "Meter", "Spawner abundance", "count"),
+      iri = c(
+        "https://w3id.org/smn/Escapement",
+        "https://w3id.org/smn/MainstemPhase",
+        "https://w3id.org/smn/Population",
+        "https://w3id.org/smn/usesObservationProcedure",
+        "http://qudt.org/vocab/unit/M",
+        "https://w3id.org/gcdfo/salmon#SpawnerAbundance",
+        "http://purl.obolibrary.org/obo/STATO_0000047"
+      ),
+      source = c("smn", "smn", "smn", "smn", "qudt", "gcdfo", "ols"),
+      ontology = c("smn", "smn", "smn", "smn", "qudt", "gcdfo", "stato"),
+      role = c("variable", "property", "entity", "method", "unit", "variable", "property"),
+      match_type = c("class", "concept", "class", "objectproperty", "unit", "class", "label_exact"),
+      definition = NA_character_,
+      score = c(8, 8, 8, 8, 4.4, 3, 0.8)
+    )
+    dict
+  }
+
+  pkg_path <- with_mocked_bindings(
+    suggest_semantics = fake_suggest,
+    {
+      create_sdp(
+        resources,
+        path = file.path(withr::local_tempdir(), "hydro-review-only"),
+        dataset_id = "hydro-demo",
+        seed_semantics = TRUE,
+        seed_verbose = FALSE,
+        check_updates = FALSE,
+        overwrite = TRUE
+      )
+    }
+  )
+
+  dict_written <- readr::read_csv(file.path(pkg_path, "metadata", "column_dictionary.csv"), show_col_types = FALSE)
+  water_row <- dict_written[dict_written$column_name == "water_level", , drop = FALSE]
+  count_row <- dict_written[dict_written$column_name == "spawner_count", , drop = FALSE]
+
+  expect_true(is.na(water_row$term_iri[[1]]) || water_row$term_iri[[1]] == "")
+  expect_true(is.na(water_row$property_iri[[1]]) || water_row$property_iri[[1]] == "")
+  expect_true(is.na(water_row$entity_iri[[1]]) || water_row$entity_iri[[1]] == "")
+  expect_true(is.na(water_row$method_iri[[1]]) || water_row$method_iri[[1]] == "")
+  expect_equal(water_row$unit_iri[[1]], "http://qudt.org/vocab/unit/M")
+
+  expect_equal(count_row$term_iri[[1]], "https://w3id.org/gcdfo/salmon#SpawnerAbundance")
+  expect_equal(count_row$property_iri[[1]], "http://purl.obolibrary.org/obo/STATO_0000047")
+})
+
 test_that("create_sdp can broaden code-level semantic seeding and optionally check for updates", {
   resources <- list(
     catches = tibble::tibble(


### PR DESCRIPTION
## Summary
- guard measurement auto-apply for broad physical/environmental headers so weak semantic matches stay review-only
- normalize wide header queries and header-derived units for water level, discharge, rainfall, snowfall, and temperature cases
- add focused regressions for the measurement-query normalization and review-only auto-apply behavior

## Verification
- `Rscript -e 'devtools::test_file("tests/testthat/test-dictionary-helpers.R"); devtools::test_file("tests/testthat/test-package-helpers.R")'`
- `Rscript -e "devtools::test()"`

## Lab evidence reused
- hydrometric `Water Level / Niveau d'eau (m)` / `Discharge / Débit (cms)`
- climate `Max Temp (°C)` / `Total Rain (mm)` / `Total Snow (cm)`
- prior same-day recommendation queue evidence captured in semantic-lab artifacts
