### PR TITLE
Improve unit-role semantic source selection

### DIFF
--- a/R/semantics-helpers.R
+++ b/R/semantics-helpers.R
@@ -612,6 +612,12 @@ suggest_semantics <- function(df,
       NA_character_
     )
   }
+  sources_for_target_role <- function(base_sources, search_role) {
+    if (length(base_sources) == 0) return(base_sources)
+    if (!identical(search_role, "unit")) return(base_sources)
+
+    unique(c(base_sources, sources_for_role("unit")))
+  }
   targets <- tibble::tibble()
 
   if (nrow(dict) > 0) {
@@ -788,7 +794,8 @@ suggest_semantics <- function(df,
   suggestions <- purrr::map_dfr(seq_len(nrow(targets)), function(i) {
     target <- targets[i, , drop = FALSE]
     search_role <- if ("search_role" %in% names(target)) target$search_role[[1]] else target$dictionary_role[[1]]
-    res <- search_fn(target$search_query[[1]], role = search_role, sources = sources)
+    target_sources <- sources_for_target_role(sources, search_role)
+    res <- search_fn(target$search_query[[1]], role = search_role, sources = target_sources)
     if (nrow(res) == 0) return(tibble::tibble())
     res <- res[!duplicated(paste(res$source, res$iri, sep = "::")), , drop = FALSE]
     if (!"role_hints" %in% names(res)) {

--- a/tests/testthat/test-dictionary-helpers.R
+++ b/tests/testthat/test-dictionary-helpers.R
@@ -431,6 +431,60 @@ test_that("suggest_semantics normalizes wide measurement headers and header unit
   expect_true(any(call_df$role == "unit" & call_df$query == "cubic meter per second"))
 })
 
+test_that("suggest_semantics augments unit-role sources with role defaults", {
+  dict <- tibble::tibble(
+    dataset_id = "d1",
+    table_id = "t1",
+    column_name = "Max Temp (°C)",
+    column_label = "Max Temp (°C)",
+    column_description = NA_character_,
+    column_role = "measurement",
+    value_type = "number",
+    unit_label = NA_character_,
+    unit_iri = NA_character_,
+    term_iri = NA_character_,
+    property_iri = NA_character_,
+    entity_iri = NA_character_,
+    constraint_iri = NA_character_,
+    method_iri = NA_character_
+  )
+
+  calls <- list()
+  fake_search <- function(query, role, sources) {
+    calls[[length(calls) + 1]] <<- tibble::tibble(
+      query = query,
+      role = role,
+      sources = list(sources)
+    )
+    tibble::tibble(
+      label = paste("candidate", role),
+      iri = paste0("https://example.org/", role),
+      source = "ols",
+      ontology = "demo",
+      role = role,
+      match_type = "label_partial",
+      definition = ""
+    )
+  }
+
+  suggest_semantics(
+    NULL,
+    dict,
+    sources = c("smn", "gcdfo", "ols", "nvs"),
+    max_per_role = 1,
+    search_fn = fake_search
+  )
+
+  call_df <- dplyr::bind_rows(calls)
+  unit_sources <- call_df$sources[call_df$role == "unit"][[1]]
+  variable_sources <- call_df$sources[call_df$role == "variable"][[1]]
+
+  expect_true("qudt" %in% unit_sources)
+  expect_true(all(c("smn", "gcdfo", "ols", "nvs") %in% unit_sources))
+  expect_false("qudt" %in% variable_sources)
+  expect_equal(variable_sources, c("smn", "gcdfo", "ols", "nvs"))
+})
+
 test_that("suggest_semantics ignores review placeholders when building table observation-unit queries", {
   dict <- tibble::tibble(
     dataset_id = "d1",

--- a/tests/testthat/test-package-helpers.R
+++ b/tests/testthat/test-package-helpers.R
@@ -546,6 +546,87 @@ test_that("create_sdp keeps broad physical measurement matches review-only but s
   expect_equal(count_row$property_iri[[1]], "http://purl.obolibrary.org/obo/STATO_0000047")
 })
 
+test_that("create_sdp unit seeding can use role-augmented unit sources", {
+  resources <- list(
+    hydro = tibble::tibble(
+      `Water Level / Niveau d'eau (m)` = c(1.2, 1.3)
+    )
+  )
+
+  calls <- list()
+  fake_find_terms <- function(query, role = NA_character_, sources = c("smn", "gcdfo", "ols", "nvs"), ...) {
+    calls[[length(calls) + 1]] <<- tibble::tibble(
+      query = query,
+      role = role,
+      sources = list(sources)
+    )
+
+    if (identical(role, "unit")) {
+      if ("qudt" %in% sources) {
+        return(tibble::tibble(
+          label = "Meter",
+          iri = "http://qudt.org/vocab/unit/M",
+          source = "qudt",
+          ontology = "qudt",
+          role = "unit",
+          match_type = "label_exact",
+          definition = "Length unit",
+          score = 4.5
+        ))
+      }
+      return(tibble::tibble(
+        label = "Degrees Celsius kilogram per square metre",
+        iri = "http://vocab.nerc.ac.uk/collection/P06/current/UFAKE/",
+        source = "nvs",
+        ontology = "P06",
+        role = "unit",
+        match_type = "label_partial",
+        definition = "Bad blended candidate",
+        score = 0.1
+      ))
+    }
+
+    tibble::tibble(
+      label = "Escapement",
+      iri = paste0("https://example.org/", role),
+      source = "ols",
+      ontology = "demo",
+      role = role,
+      match_type = "label_partial",
+      definition = "Generic candidate",
+      score = 0.2
+    )
+  }
+
+  pkg_path <- with_mocked_bindings(
+    find_terms = fake_find_terms,
+    {
+      create_sdp(
+        resources,
+        path = file.path(withr::local_tempdir(), "hydro-unit-sources"),
+        dataset_id = "hydro-unit-demo",
+        seed_semantics = TRUE,
+        semantic_sources = c("smn", "gcdfo", "ols", "nvs"),
+        seed_verbose = FALSE,
+        check_updates = FALSE,
+        overwrite = TRUE
+      )
+    }
+  )
+
+  dict_written <- readr::read_csv(file.path(pkg_path, "metadata", "column_dictionary.csv"), show_col_types = FALSE)
+  water_row <- dict_written[dict_written$column_name == "Water Level / Niveau d'eau (m)", , drop = FALSE]
+
+  expect_equal(water_row$unit_iri[[1]], "http://qudt.org/vocab/unit/M")
+  expect_true(is.na(water_row$term_iri[[1]]) || water_row$term_iri[[1]] == "")
+  expect_true(is.na(water_row$property_iri[[1]]) || water_row$property_iri[[1]] == "")
+
+  call_df <- dplyr::bind_rows(calls)
+  unit_sources <- call_df$sources[call_df$role == "unit"][[1]]
+  expect_true("qudt" %in% unit_sources)
+  expect_true(all(c("smn", "gcdfo", "ols", "nvs") %in% unit_sources))
+})
+
 test_that("create_sdp can broaden code-level semantic seeding and optionally check for updates", {
   resources <- list(
     catches = tibble::tibble(


### PR DESCRIPTION
## Summary
- augment unit-role semantic suggestion searches with role-appropriate unit sources, including QUDT
- keep non-unit suggestion source behavior unchanged
- add deterministic tests for unit-role source augmentation and create_sdp unit seeding

## Verification
- `Rscript -e "pkgload::load_all('/tmp/metasalmon-promotion-20260319T1347Z', quiet=TRUE); testthat::test_file('/tmp/metasalmon-promotion-20260319T1347Z/tests/testthat/test-dictionary-helpers.R', reporter='summary')"`
- `Rscript -e "pkgload::load_all('/tmp/metasalmon-promotion-20260319T1347Z', quiet=TRUE); testthat::test_file('/tmp/metasalmon-promotion-20260319T1347Z/tests/testthat/test-package-helpers.R', reporter='summary')"`
- `Rscript -e "devtools::test()"`

## Evidence
- live spot-check after patch returned QUDT `Degree Celsius` for `Max Temp (°C)` and QUDT `Meter` for `Water Level / Niveau d'eau (m)` when using default semantic sources.
