### PR TITLE
fix: suppress long-format helper term seeding

### DIFF
--- a/R/semantics-helpers.R
+++ b/R/semantics-helpers.R
@@ -566,10 +566,47 @@ suggest_semantics <- function(df,
 
     grepl("\\b(watershed|waterbody|river|stream|location|site)\\b", query_text, perl = TRUE)
   }
+  same_table_column_names <- function(row, dict) {
+    if (nrow(dict) == 0 || !all(c("dataset_id", "table_id", "column_name") %in% names(dict))) {
+      return(character())
+    }
+
+    keep <- rep(TRUE, nrow(dict))
+    for (key in intersect(c("dataset_id", "table_id"), names(dict))) {
+      value <- row[[key]][[1]]
+      if (!is.na(value) && nzchar(as.character(value))) {
+        keep <- keep & !is.na(dict[[key]]) & as.character(dict[[key]]) == as.character(value)
+      }
+    }
+
+    cols <- trimws(tolower(as.character(dict$column_name[keep])))
+    unique(cols[nzchar(cols)])
+  }
+  has_long_format_observation_value_pattern <- function(row, dict) {
+    cols <- same_table_column_names(row, dict)
+    if (length(cols) == 0) {
+      return(FALSE)
+    }
+
+    has_value <- "value" %in% cols
+    has_variable <- any(cols %in% c("variable_name", "measurement_name", "parameter_name", "analyte_name"))
+    has_unit <- any(cols %in% c("unit_code", "unit", "unit_label"))
+
+    has_value && has_variable && has_unit
+  }
+  is_long_format_observation_helper <- function(row, dict) {
+    col_name <- tolower(trimws(as.character(row$column_name[[1]] %||% "")))
+    if (!nzchar(col_name) || !has_long_format_observation_value_pattern(row, dict)) {
+      return(FALSE)
+    }
+
+    col_name %in% c("unit_code", "vmv_code", "flag", "status", "method_detect_limit", "station_name")
+  }
   non_measurement_roles <- function(row, codes, dict) {
     role <- tolower(as.character(row$column_role[[1]] %||% ""))
     if (!nzchar(role) || role %in% c("identifier", "temporal")) return(character())
     if (.ms_is_text_like_field_name(row$column_name[[1]] %||% "")) return(character())
+    if (is_long_format_observation_helper(row, dict)) return(character())
 
     term_missing <- "term_iri" %in% names(row) && is_missing(row$term_iri[[1]])
     if (!term_missing) return(character())

--- a/tests/testthat/test-dictionary-helpers.R
+++ b/tests/testthat/test-dictionary-helpers.R
@@ -601,6 +601,118 @@ test_that("suggest_semantics adds lighter non-measurement term suggestions for c
   expect_false(any(non_measurement$column_name == "survey_comment"))
 })
 
+test_that("suggest_semantics keeps long-format observation helpers review-only", {
+  dict <- tibble::tibble(
+    dataset_id = c(rep("d1", 8), "d1"),
+    table_id = c(rep("water_quality", 8), "water_quality"),
+    column_name = c(
+      "value",
+      "variable_name",
+      "unit_code",
+      "vmv_code",
+      "flag",
+      "status",
+      "method_detect_limit",
+      "station_name",
+      "sample_type"
+    ),
+    column_label = c(
+      "value",
+      "variable_name",
+      "unit_code",
+      "vmv_code",
+      "flag",
+      "status",
+      "method_detect_limit",
+      "station_name",
+      "sample_type"
+    ),
+    column_description = c(
+      "Observed value",
+      "Reported variable name",
+      "Reported unit code",
+      "Variable method code",
+      "Quality flag",
+      "Record status",
+      "Method detection limit",
+      "Station name",
+      "Sample type"
+    ),
+    column_role = c(
+      "attribute",
+      "attribute",
+      "attribute",
+      "attribute",
+      "attribute",
+      "attribute",
+      "attribute",
+      "attribute",
+      "attribute"
+    ),
+    value_type = c("number", "string", "string", "string", "string", "string", "string", "string", "string"),
+    unit_label = rep(NA_character_, 9),
+    unit_iri = rep(NA_character_, 9),
+    term_iri = rep(NA_character_, 9),
+    property_iri = rep(NA_character_, 9),
+    entity_iri = rep(NA_character_, 9),
+    constraint_iri = rep(NA_character_, 9),
+    method_iri = rep(NA_character_, 9)
+  )
+  codes <- tibble::tibble(
+    dataset_id = rep("d1", 7),
+    table_id = rep("water_quality", 7),
+    column_name = c("unit_code", "vmv_code", "flag", "status", "method_detect_limit", "station_name", "sample_type"),
+    code_value = c("MG/L", "97998", "U", "A", "0.2", "Fraser River at Hansard", "Routine"),
+    code_label = c("Milligrams per litre", "Aluminum total", "Unchecked", "Approved", "0.2", "Fraser River at Hansard", "Routine"),
+    code_description = c(
+      "Reported unit code",
+      "Variable code",
+      "Quality flag",
+      "Status code",
+      "Detection limit",
+      "Monitoring station name",
+      "Sample type"
+    ),
+    vocabulary_iri = rep(NA_character_, 7),
+    term_iri = rep(NA_character_, 7),
+    term_type = rep(NA_character_, 7)
+  )
+
+  calls <- list()
+  fake_search <- function(query, role, sources) {
+    calls[[length(calls) + 1]] <<- list(query = query, role = role)
+    tibble::tibble(
+      label = paste("candidate", role),
+      iri = paste0("https://example.org/", role, "/", gsub("\\s+", "-", tolower(query))),
+      source = "ols",
+      ontology = "demo",
+      role = role,
+      match_type = "label_partial",
+      definition = ""
+    )
+  }
+
+  res <- suggest_semantics(
+    NULL,
+    dict,
+    sources = "ols",
+    max_per_role = 1,
+    search_fn = fake_search,
+    codes = codes
+  )
+
+  suggestions <- attr(res, "semantic_suggestions")
+  helper_cols <- c("unit_code", "vmv_code", "flag", "status", "method_detect_limit", "station_name")
+  column_suggestions <- suggestions[suggestions$target_scope == "column" & suggestions$target_sdp_field == "term_iri", , drop = FALSE]
+
+  expect_false(any(column_suggestions$column_name %in% helper_cols))
+  expect_true(any(column_suggestions$column_name == "sample_type"))
+
+  call_df <- tibble::as_tibble(purrr::map_dfr(calls, tibble::as_tibble))
+  expect_false(any(call_df$query %in% c("unit code", "vmv code", "flag", "status", "method detect limit", "station name")))
+  expect_true(any(call_df$query == "sample type"))
+})
+
 test_that("suggest_semantics uses role-aware search roles for controlled attribute term suggestions", {
   dict <- tibble::tibble(
     dataset_id = c("d1", "d1", "d1", "d1", "d1"),


### PR DESCRIPTION
## Summary
- suppress term suggestions for long-format helper columns like unit_code, vmv_code, flag, status, method_detect_limit, and station_name when the table already has the value/variable/unit pattern
- keep actual descriptive fields such as sample_type in the review queue
- cover the helper suppression behaviour with dictionary-helper tests

## Validation
- Rscript -e "pkgload::load_all(quiet=TRUE); testthat::test_file('tests/testthat/test-dictionary-helpers.R')" *(current baseline still has one pre-existing failure on main in `validate_dictionary catches missing columns`; branch adds four passing assertions around helper suppression)*

## Why
This keeps reviewer output focused when SPSR-supporting long-format packages pass through metasalmon semantic suggestion flows.