### PR TITLE
Restore strict dictionary column validation

### DIFF
--- a/R/dictionary-helpers.R
+++ b/R/dictionary-helpers.R
@@ -702,7 +702,7 @@ infer_column_role <- function(col_name, col) {
 #' validate_dictionary(dict)
 #' }
 validate_dictionary <- function(dict, require_iris = FALSE) {
-  dict <- .ms_dictionary_from_input(dict)
+  dict <- .ms_dictionary_from_input(dict, normalize = FALSE)
 
   # Required columns
   required_cols <- c(
@@ -715,6 +715,11 @@ validate_dictionary <- function(dict, require_iris = FALSE) {
     cli::cli_abort(
       "Dictionary missing required columns: {.field {missing_cols}}"
     )
+  }
+
+  dict <- .ms_normalize_dictionary(dict)
+  if ("required" %in% names(dict)) {
+    dict$required <- .ms_parse_logical(dict$required)
   }
 
   # Ensure optional semantic columns exist (fill with NA if absent)

--- a/R/package-helpers.R
+++ b/R/package-helpers.R
@@ -1013,11 +1013,14 @@ validate_salmon_datapackage <- function(path, require_iris = FALSE) {
   as.logical(out)
 }
 
-.ms_dictionary_from_input <- function(dict) {
+.ms_dictionary_from_input <- function(dict, normalize = TRUE) {
   if (inherits(dict, "data.frame")) {
-    dict <- .ms_normalize_dictionary(dict)
-    if ("required" %in% names(dict)) {
-      dict$required <- .ms_parse_logical(dict$required)
+    dict <- tibble::as_tibble(dict)
+    if (isTRUE(normalize)) {
+      dict <- .ms_normalize_dictionary(dict)
+      if ("required" %in% names(dict)) {
+        dict$required <- .ms_parse_logical(dict$required)
+      }
     }
     return(dict)
   }
@@ -1040,9 +1043,11 @@ validate_salmon_datapackage <- function(path, require_iris = FALSE) {
     }
 
     dict <- .ms_read_metadata_csv(dict_path)
-    dict <- .ms_normalize_dictionary(dict)
-    if ("required" %in% names(dict)) {
-      dict$required <- .ms_parse_logical(dict$required)
+    if (isTRUE(normalize)) {
+      dict <- .ms_normalize_dictionary(dict)
+      if ("required" %in% names(dict)) {
+        dict$required <- .ms_parse_logical(dict$required)
+      }
     }
     return(dict)
   }


### PR DESCRIPTION
## Summary
- stop `validate_dictionary()` from normalizing missing required columns into existence before validation
- let `.ms_dictionary_from_input()` return raw dictionary input when callers need structural checks first
- keep downstream normalization/parsing after the required-column gate so optional semantic columns still get filled consistently

## Verification
- `Rscript -e "devtools::test_file('tests/testthat/test-dictionary-helpers.R')"`
- `Rscript -e "devtools::test()"`
