### PR TITLE
Guard explicit sample-size fields as measurements

### DIFF
--- a/R/dictionary-helpers.R
+++ b/R/dictionary-helpers.R
@@ -607,6 +607,13 @@ infer_value_type <- function(col) {
   any(name_tokens %in% number_tokens) && any(name_tokens %in% identifier_context_tokens)
 }
 
+.ms_name_has_sample_size_hint <- function(name_tokens) {
+  size_tokens <- c("size", "sizes")
+  sample_context_tokens <- c("sample", "samples", "partition", "partitions")
+
+  any(name_tokens %in% size_tokens) && any(name_tokens %in% sample_context_tokens)
+}
+
 #' Infer column role from name and data
 #'
 #' @param col_name Column name
@@ -650,6 +657,12 @@ infer_column_role <- function(col_name, col) {
   )
   if (any(name_tokens %in% method_tokens)) {
     return("attribute")
+  }
+
+  # Explicit sample-size / partition-size count fields should stay in the
+  # measurement lane even when they lack generic count/amount tokens.
+  if (.ms_name_has_sample_size_hint(name_tokens) && .ms_values_look_numericish(col)) {
+    return("measurement")
   }
 
   # Check for measurement/quantity patterns. Wide real-world tables often hide
@@ -978,3 +991,4 @@ apply_salmon_dictionary <- function(df, dict, codes = NULL, strict = TRUE) {
 
   result
 }
+

--- a/tests/testthat/test-dictionary-helpers.R
+++ b/tests/testthat/test-dictionary-helpers.R
@@ -89,6 +89,24 @@ test_that("infer_dictionary keeps method-like count fields out of measurement ro
   expect_equal(dict$column_role[dict$column_name == "avg_weight"], "measurement")
 })
 
+test_that("infer_dictionary promotes explicit sample-size and partition-size counts without reopening nearby helper fields", {
+  df <- tibble::tibble(
+    mr_1st_sample_size = c(12, 15),
+    mr_1st_partition_size = c(20, 24),
+    sample_type = c("A", "B"),
+    sample_reference_number = c("REF-1", "REF-2"),
+    sample_date = as.Date(c("2024-01-01", "2024-01-02"))
+  )
+
+  dict <- infer_dictionary(df, dataset_id = "test-1", table_id = "table-1")
+
+  expect_equal(dict$column_role[dict$column_name == "mr_1st_sample_size"], "measurement")
+  expect_equal(dict$column_role[dict$column_name == "mr_1st_partition_size"], "measurement")
+  expect_equal(dict$column_role[dict$column_name == "sample_type"], "attribute")
+  expect_equal(dict$column_role[dict$column_name == "sample_reference_number"], "identifier")
+  expect_equal(dict$column_role[dict$column_name == "sample_date"], "temporal")
+})
+
 test_that("infer_dictionary recognizes wide numeric and percent metrics without promoting QA or reference fields", {
   df <- tibble::tibble(
     `Facility Reference Number` = c(1001, 1002),


### PR DESCRIPTION
## Summary
- classify explicit numeric `*_sample_size` / `*_partition_size` columns as measurements before the generic substring heuristic
- keep nearby helper fields like `sample_type`, `sample_reference_number`, and `sample_date` in their safer non-measurement lanes
- add regression coverage for the CWT catch/sample role-inference slice

## Verification
- `Rscript -e "devtools::test_file("tests/testthat/test-dictionary-helpers.R")"`
- focused `infer_dictionary()` role check for `mr_1st_sample_size` / `mr_1st_partition_size`
- `Rscript -e "devtools::test()"`