### PR TITLE
improve: refine semantic ranking for physical and hydrometric queries

### DIFF
--- a/R/term_search.R
+++ b/R/term_search.R
@@ -58,10 +58,46 @@
       genus <- sub(" .*", "", query)
       queries <- c(queries, genus)
     }
-  } else if (role == "property") {
-    # Add "measurement" or "observation" context if not present
-    if (!grepl("measurement|observation|count|abundance|length|weight|size", query, ignore.case = TRUE)) {
-      queries <- c(queries, paste(query, "measurement"))
+  } else if (role %in% c("variable", "property")) {
+    q_lower <- tolower(trimws(query))
+    focus <- .physical_query_focus(query)
+
+    if (focus == "level") {
+      if (!grepl("\\b(stage height|gauge height)\\b", q_lower)) {
+        queries <- c(queries, "stage height", "gauge height")
+      }
+      if (!grepl("\\b(surface elevation)\\b", q_lower)) {
+        queries <- c(queries, "surface elevation")
+      }
+      if (!grepl("\\b(river level|stream level)\\b", q_lower)) {
+        queries <- c(queries, "river level", "stream level")
+      }
+    }
+
+    if (focus == "discharge") {
+      if (!identical(q_lower, "discharge")) {
+        queries <- c(queries, "discharge")
+      }
+      if (!grepl("\\b(stream discharge|streamflow)\\b", q_lower)) {
+        queries <- c(queries, "stream discharge", "streamflow")
+      }
+      if (!grepl("\\b(water discharge|river discharge)\\b", q_lower)) {
+        queries <- c(queries, "water discharge", "river discharge")
+      }
+      if (!grepl("\\briverine discharge\\b", q_lower)) {
+        queries <- c(queries, "riverine discharge")
+      }
+    }
+
+    if (focus == "temperature" && grepl("\\btemp\\b", q_lower) && !grepl("temperature", q_lower)) {
+      queries <- c(queries, "water temperature")
+    }
+
+    if (role == "property") {
+      # Add "measurement" context for property searches if absent.
+      if (!grepl("measurement|observation|count|abundance|length|weight|size", query, ignore.case = TRUE)) {
+        queries <- c(queries, paste(query, "measurement"))
+      }
     }
   }
 
@@ -1090,24 +1126,41 @@ pattern <- paste(tokens, collapse = ".*")
   }
 
   if (focus == "level") {
-    if (grepl("water level|level of water|river level|stage height|gauge height", label_text)) {
-      bonus <- bonus + 2
+    if (grepl("water level|level of water|river level|stream level|stage height|gauge height", label_text)) {
+      bonus <- bonus + 2.8
+    } else if (grepl("surface elevation", label_text) && grepl("water|river|stream", label_text)) {
+      bonus <- bonus + 2.2
+    } else if (grepl("\\blevel\\b", label_text) && grepl("water|river|stream|stage|gauge", label_text)) {
+      bonus <- bonus + 0.6
     } else {
-      bonus <- bonus - 1.8
+      bonus <- bonus - 2.2
     }
-    if (grepl("wave|period|pressure|ice|freeboard|radar|organic carbon|concentration|uptake|production", label_text)) {
-      bonus <- bonus - 2.5
+    if (grepl("\\b(discharge|streamflow|flow rate|riverine discharge)\\b", label_text)) {
+      bonus <- bonus - 4.2
+    }
+    if (grepl("wave|period|pressure|ice|freeboard|radar|spectral|organic carbon|concentration|uptake|production", label_text)) {
+      bonus <- bonus - 3.6
     }
   }
 
   if (focus == "discharge") {
-    if (grepl("discharge|flow rate|streamflow|riverine discharge|flow", label_text)) {
-      bonus <- bonus + 1.8
+    if (grepl("stream discharge|water discharge|river discharge|riverine discharge|streamflow|flow rate", label_text)) {
+      bonus <- bonus + 2.2
+    } else if (grepl("\\bdischarge\\b", label_text) && grepl("water|river|stream", label_text)) {
+      bonus <- bonus + 1.2
+    } else if (grepl("\\bflow\\b", label_text)) {
+      bonus <- bonus + 0.2
     } else {
-      bonus <- bonus - 1.3
+      bonus <- bonus - 1.4
     }
-    if (grepl("pollution|shoreline|proportion|coverage", label_text)) {
-      bonus <- bonus - 2.2
+    if (is_local && !grepl("discharge|flow", label_text)) {
+      bonus <- bonus - 2.8
+    }
+    if (any(query_tokens %in% c("stream", "river", "water")) && !grepl("stream|river|water", label_text)) {
+      bonus <- bonus - 1.2
+    }
+    if (grepl("electrical|pollution|shoreline|proportion|coverage|sediment|nutrient", label_text)) {
+      bonus <- bonus - 2.4
     }
   }
 

--- a/tests/testthat/fixtures/semantic-ranking-fixtures.json
+++ b/tests/testthat/fixtures/semantic-ranking-fixtures.json
@@ -1156,5 +1156,142 @@
         "backend_score": 1.6
       }
     ]
+  },
+  {
+    "case_id": "water-level-prefers-surface-elevation-over-hydrometric-noise",
+    "query": "water level",
+    "role": "variable",
+    "expected": {
+      "top": {
+        "candidate_id": "surface-elevation-water-body",
+        "source": "nvs"
+      },
+      "disallow_top_matches": [
+        "RFDSCH13",
+        "ICESFB01"
+      ]
+    },
+    "candidates": [
+      {
+        "candidate_id": "hydrometric-discharge-from-level",
+        "label": "Riverine discharge (daily mean) of water by water level gauge and calculation from level",
+        "iri": "http://vocab.nerc.ac.uk/collection/P01/current/RFDSCH13/",
+        "source": "nvs",
+        "ontology": "P01",
+        "role": "variable",
+        "match_type": "concept",
+        "definition": "Daily mean discharge calculated from a water level gauge.",
+        "backend_score": 2.8
+      },
+      {
+        "candidate_id": "noisy-ice-freeboard",
+        "label": "Thickness (above water level) of ice {freeboard} on the water body by ice profiler",
+        "iri": "http://vocab.nerc.ac.uk/collection/P01/current/ICESFB01/",
+        "source": "nvs",
+        "ontology": "P01",
+        "role": "variable",
+        "match_type": "concept",
+        "definition": "Ice freeboard over water level.",
+        "backend_score": 2.4
+      },
+      {
+        "candidate_id": "surface-elevation-water-body",
+        "label": "Surface elevation relative to unspecified datum of the water body",
+        "iri": "http://vocab.nerc.ac.uk/collection/P01/current/ASLVZZ01/",
+        "source": "nvs",
+        "ontology": "P01",
+        "role": "variable",
+        "match_type": "concept",
+        "definition": "Surface elevation of the water body relative to an unspecified datum.",
+        "backend_score": 1.6
+      }
+    ]
+  },
+  {
+    "case_id": "water-discharge-prefers-hydrometric-over-local-river-drift",
+    "query": "water discharge",
+    "role": "variable",
+    "expected": {
+      "top": {
+        "candidate_id": "riverine-discharge-water",
+        "source": "nvs"
+      },
+      "disallow_top_matches": [
+        "IndicatorRiver"
+      ]
+    },
+    "candidates": [
+      {
+        "candidate_id": "indicator-river",
+        "label": "Indicator river",
+        "iri": "https://w3id.org/smn/IndicatorRiver",
+        "source": "smn",
+        "ontology": "smn",
+        "role": "variable",
+        "match_type": "class",
+        "definition": "River selected as an indicator system.",
+        "backend_score": 3.0
+      },
+      {
+        "candidate_id": "generic-discharge",
+        "label": "Electrical discharge current",
+        "iri": "http://example.org/physics/electrical-discharge",
+        "source": "ols",
+        "ontology": "physics",
+        "role": "variable",
+        "match_type": "label_exact",
+        "definition": "Electrical discharge of current in a conductor.",
+        "backend_score": 3.2
+      },
+      {
+        "candidate_id": "riverine-discharge-water",
+        "label": "Riverine discharge (daily mean) of water",
+        "iri": "http://vocab.nerc.ac.uk/collection/P01/current/RFDSCH11/",
+        "source": "nvs",
+        "ontology": "P01",
+        "role": "variable",
+        "match_type": "concept",
+        "definition": "Daily mean stream/river water discharge.",
+        "backend_score": 1.8
+      }
+    ]
+  },
+  {
+    "case_id": "water-temperature-stays-physical-over-local-drift",
+    "query": "water temperature",
+    "role": "variable",
+    "expected": {
+      "top": {
+        "candidate_id": "water-temperature",
+        "source": "nvs"
+      },
+      "disallow_top_matches": [
+        "w3id.org/smn/Escapement"
+      ]
+    },
+    "candidates": [
+      {
+        "candidate_id": "local-escapement",
+        "label": "Escapement",
+        "iri": "https://w3id.org/smn/Escapement",
+        "source": "smn",
+        "ontology": "smn",
+        "role": "variable",
+        "match_type": "class",
+        "definition": "Count of salmon returning to spawn.",
+        "backend_score": 3.0
+      },
+      {
+        "candidate_id": "water-temperature",
+        "label": "Water temperature",
+        "iri": "http://vocab.nerc.ac.uk/collection/P01/current/TEMPPR01/",
+        "source": "nvs",
+        "ontology": "P01",
+        "role": "variable",
+        "match_type": "label_exact",
+        "definition": "Temperature of water body.",
+        "backend_score": 1.8
+      }
+    ]
   }
 ]

--- a/tests/testthat/test-term-search.R
+++ b/tests/testthat/test-term-search.R
@@ -760,6 +760,21 @@ test_that("query expansion extracts genus for entity role", {
   expect_true("Oncorhynchus" %in% expanded)
 })
 
+test_that("query expansion adds hydrometric variants for variable/property roles", {
+  level_expanded <- metasalmon:::.expand_query("water level", "variable")
+  expect_true("stage height" %in% level_expanded)
+  expect_true("gauge height" %in% level_expanded)
+  expect_true("surface elevation" %in% level_expanded)
+
+  discharge_expanded <- metasalmon:::.expand_query("water discharge", "variable")
+  expect_true("discharge" %in% discharge_expanded)
+  expect_true("riverine discharge" %in% discharge_expanded)
+  expect_true("streamflow" %in% discharge_expanded)
+
+  property_expanded <- metasalmon:::.expand_query("water discharge", "property")
+  expect_true("water discharge measurement" %in% property_expanded)
+})
+
 test_that("query expansion returns original when role is NA", {
   expanded <- metasalmon:::.expand_query("salmon", NA)
   expect_equal(expanded, "salmon")


### PR DESCRIPTION
## Summary
- improve ranking for physical and environmental queries so water temperature, freshwater body, and similar terms outrank salmon-domain drift when the query is clearly environmental
- add hydrometric query expansion and ranking coverage so water level / stage / discharge searches surface the right variable and property candidates more consistently
- reduce method-query drift by demoting count-like metrics when the user is actually asking for methods or protocols
- add a semantic ranking fixture pack to lock in deterministic top-result ordering for the new ranking cases

## Verification
- reran `testthat::test_file("tests/testthat/test-term-search.R")` — passed (`PASS 252`)

## Notes
- scope stays limited to `R/term_search.R` plus ranking fixtures/tests
- no merge included here; this is the focused ranking slice only
