### PR TITLE
Recover snake-case Degree C unit cues from full headers

### DIFF
--- a/R/semantics-helpers.R
+++ b/R/semantics-helpers.R
@@ -235,13 +235,20 @@ suggest_semantics <- function(df,
     for (text in texts) {
       matches <- gregexpr("\\(([^)]{1,20})\\)", text, perl = TRUE)
       pieces <- regmatches(text, matches)[[1]]
-      if (length(pieces) == 0) next
-      pieces <- trimws(gsub("^\\(|\\)$", "", pieces))
-      pieces <- pieces[nzchar(pieces)]
-      if (length(pieces) == 0) next
-      normalized <- normalize_measurement_unit_query(utils::tail(pieces, 1))
-      if (nzchar(normalized)) {
-        return(normalized)
+      if (length(pieces) > 0) {
+        pieces <- trimws(gsub("^\\(|\\)$", "", pieces))
+        pieces <- pieces[nzchar(pieces)]
+        if (length(pieces) > 0) {
+          normalized <- normalize_measurement_unit_query(utils::tail(pieces, 1))
+          if (nzchar(normalized)) {
+            return(normalized)
+          }
+        }
+      }
+
+      normalized_full_text <- normalize_measurement_unit_query(text)
+      if (nzchar(normalized_full_text)) {
+        return(normalized_full_text)
       }
     }
 

--- a/tests/testthat/test-dictionary-helpers.R
+++ b/tests/testthat/test-dictionary-helpers.R
@@ -408,20 +408,20 @@ test_that("suggest_semantics uses count-like measurement queries for adult spawn
 
 test_that("suggest_semantics normalizes wide measurement headers and header units", {
   dict <- tibble::tibble(
-    dataset_id = c("d1", "d1", "d1"),
-    table_id = c("t1", "t1", "t1"),
-    column_name = c("Water Level / Niveau d'eau (m)", "Max Temp (°C)", "Discharge / Débit (cms)"),
-    column_label = c("Water Level / Niveau d'eau (m)", "Max Temp (°C)", "Discharge / Débit (cms)"),
-    column_description = c(NA_character_, NA_character_, NA_character_),
-    column_role = c("measurement", "measurement", "measurement"),
-    value_type = c("number", "number", "number"),
-    unit_label = c(NA_character_, NA_character_, NA_character_),
-    unit_iri = c(NA_character_, NA_character_, NA_character_),
-    term_iri = c(NA_character_, NA_character_, NA_character_),
-    property_iri = c(NA_character_, NA_character_, NA_character_),
-    entity_iri = c(NA_character_, NA_character_, NA_character_),
-    constraint_iri = c(NA_character_, NA_character_, NA_character_),
-    method_iri = c(NA_character_, NA_character_, NA_character_)
+    dataset_id = c("d1", "d1", "d1", "d1"),
+    table_id = c("t1", "t1", "t1", "t1"),
+    column_name = c("Water Level / Niveau d'eau (m)", "Max Temp (°C)", "Discharge / Débit (cms)", "temperature_degree_c"),
+    column_label = c("Water Level / Niveau d'eau (m)", "Max Temp (°C)", "Discharge / Débit (cms)", "temperature_degree_c"),
+    column_description = c(NA_character_, NA_character_, NA_character_, NA_character_),
+    column_role = c("measurement", "measurement", "measurement", "measurement"),
+    value_type = c("number", "number", "number", "number"),
+    unit_label = c(NA_character_, NA_character_, NA_character_, NA_character_),
+    unit_iri = c(NA_character_, NA_character_, NA_character_, NA_character_),
+    term_iri = c(NA_character_, NA_character_, NA_character_, NA_character_),
+    property_iri = c(NA_character_, NA_character_, NA_character_, NA_character_),
+    entity_iri = c(NA_character_, NA_character_, NA_character_, NA_character_),
+    constraint_iri = c(NA_character_, NA_character_, NA_character_, NA_character_),
+    method_iri = c(NA_character_, NA_character_, NA_character_, NA_character_)
   )
 
   calls <- list()

--- a/tests/testthat/test-package-helpers.R
+++ b/tests/testthat/test-package-helpers.R
@@ -549,7 +549,8 @@ test_that("create_sdp keeps broad physical measurement matches review-only but s
 test_that("create_sdp unit seeding can use role-augmented unit sources", {
   resources <- list(
     hydro = tibble::tibble(
-      `Water Level / Niveau d'eau (m)` = c(1.2, 1.3)
+      `Water Level / Niveau d'eau (m)` = c(1.2, 1.3),
+      temperature_degree_c = c(6.1, 6.4)
     )
   )
 
@@ -563,6 +564,18 @@ test_that("create_sdp unit seeding can use role-augmented unit sources", {
 
     if (identical(role, "unit")) {
       if ("qudt" %in% sources) {
+        if (identical(query, "degree celsius")) {
+          return(tibble::tibble(
+            label = "Degree Celsius",
+            iri = "http://qudt.org/vocab/unit/DEG_C",
+            source = "qudt",
+            ontology = "qudt",
+            role = "unit",
+            match_type = "label_exact",
+            definition = "Temperature unit",
+            score = 4.5
+          ))
+        }
         return(tibble::tibble(
           label = "Meter",
           iri = "http://qudt.org/vocab/unit/M",
@@ -616,10 +629,14 @@ test_that("create_sdp unit seeding can use role-augmented unit sources", {
 
   dict_written <- readr::read_csv(file.path(pkg_path, "metadata", "column_dictionary.csv"), show_col_types = FALSE)
   water_row <- dict_written[dict_written$column_name == "Water Level / Niveau d'eau (m)", , drop = FALSE]
+  temp_row <- dict_written[dict_written$column_name == "temperature_degree_c", , drop = FALSE]
 
   expect_equal(water_row$unit_iri[[1]], "http://qudt.org/vocab/unit/M")
   expect_true(is.na(water_row$term_iri[[1]]) || water_row$term_iri[[1]] == "")
   expect_true(is.na(water_row$property_iri[[1]]) || water_row$property_iri[[1]] == "")
+  expect_equal(temp_row$unit_iri[[1]], "http://qudt.org/vocab/unit/DEG_C")
+  expect_true(is.na(temp_row$term_iri[[1]]) || temp_row$term_iri[[1]] == "")
+  expect_true(is.na(temp_row$property_iri[[1]]) || temp_row$property_iri[[1]] == "")
 
   call_df <- dplyr::bind_rows(calls)
   unit_sources <- call_df$sources[call_df$role == "unit"][[1]]


### PR DESCRIPTION
## Summary
- recover `Degree C` / `degree_c` unit normalization when the cue appears in full header text instead of only in parenthetical suffixes
- preserve the existing parenthetical-unit path while adding the full-header fallback needed for snake-case names like `temperature_degree_c`
- cover the fallback in dictionary and package-helper tests

## Verification
- `Rscript -e "devtools::test_file('tests/testthat/test-dictionary-helpers.R')"`
- `Rscript -e "devtools::test_file('tests/testthat/test-package-helpers.R')"`
- `Rscript -e "devtools::test()"`
