### PR TITLE
Fix semantic suggestion guards for DwC/value-unit fields

### DIFF
--- a/R/dictionary-helpers.R
+++ b/R/dictionary-helpers.R
@@ -171,6 +171,7 @@ infer_dictionary <- function(df, guess_types = TRUE, dataset_id = "dataset-1", t
         dict$column_role[i] <- infer_column_role(col_names[i], col)
         dict$required[i] <- .ms_infer_required_flag(col_names[i], col, dict$column_role[i])
       }
+      dict <- .ms_promote_paired_value_unit_measurements(dict, df)
     }
 
     if (isTRUE(seed_semantics)) {
@@ -303,6 +304,57 @@ infer_dictionary <- function(df, guess_types = TRUE, dataset_id = "dataset-1", t
   }
 
   dataset_meta
+}
+
+.ms_promote_paired_value_unit_measurements <- function(dict, df) {
+  if (!inherits(df, "data.frame") || nrow(dict) == 0) {
+    return(dict)
+  }
+
+  out <- dict
+  df_names <- names(df)
+  if (length(df_names) == 0) {
+    return(out)
+  }
+
+  for (i in seq_len(nrow(out))) {
+    role <- tolower(as.character(out$column_role[[i]] %||% ""))
+    if (!role %in% c("attribute", "categorical")) {
+      next
+    }
+
+    col_name <- out$column_name[[i]]
+    if (is.na(col_name) || !grepl("value$", col_name, ignore.case = TRUE)) {
+      next
+    }
+
+    if (!col_name %in% df_names || !.ms_values_look_numericish(df[[col_name]])) {
+      next
+    }
+
+    stem <- sub("value$", "", col_name, ignore.case = TRUE)
+    sibling_hits <- df_names[tolower(df_names) == paste0(tolower(stem), "unit")]
+    if (length(sibling_hits) == 0) {
+      next
+    }
+
+    sibling_name <- sibling_hits[[1]]
+    sibling_values <- as.character(df[[sibling_name]])
+    sibling_values <- trimws(sibling_values[!is.na(sibling_values)])
+    sibling_values <- sibling_values[nzchar(sibling_values)]
+    if (length(sibling_values) == 0) {
+      next
+    }
+
+    unique_units <- unique(sibling_values)
+    if (length(unique_units) > 10) {
+      next
+    }
+
+    out$column_role[[i]] <- "measurement"
+  }
+
+  out
 }
 
 infer_table_metadata_from_resources <- function(resources, dataset_id = "dataset-1") {

--- a/R/package-helpers.R
+++ b/R/package-helpers.R
@@ -1727,6 +1727,7 @@ validate_salmon_datapackage <- function(path, require_iris = FALSE) {
 
 .ms_measurement_query_looks_physical <- function(...) {
   text <- paste(unlist(list(...)), collapse = " ")
+  text <- gsub("([a-z0-9])([A-Z])", "\\1 \\2", text, perl = TRUE)
   text <- tolower(text)
   grepl(
     "\\b(water|level|discharge|flow|temperature|temp|rain|rainfall|snow|snowfall|precip|gust|wind|speed|depth|width|height|meter|metre|celsius)\\b",
@@ -1737,6 +1738,7 @@ validate_salmon_datapackage <- function(path, require_iris = FALSE) {
 
 .ms_normalize_measurement_unit_text <- function(x) {
   text <- tolower(.ms_scalar_text(x))
+  text <- gsub("([a-z0-9])([A-Z])", "\\1 \\2", text, perl = TRUE)
   text <- gsub("â", "", text, fixed = TRUE)
   text <- gsub("°", " degree ", text, fixed = TRUE)
   text <- gsub("³", "3", text, fixed = TRUE)
@@ -1749,6 +1751,7 @@ validate_salmon_datapackage <- function(path, require_iris = FALSE) {
   if (grepl("^(cubic meter per second|cubic metre per second|m3/s|cms|cumec|cumecs)$", text)) return("cubic meter per second")
   if (grepl("^(degree celsius|degrees celsius|deg c|celsius)$", text)) return("degree celsius")
   if (grepl("^(kilometer per hour|kilometre per hour|km/h|kph)$", text)) return("kilometer per hour")
+  if (grepl("^(square meter|square metre|square meters|square metres|sq m|m2)$", text)) return("square meter")
   if (grepl("^millimet(er|re)s?$", text)) return("millimeter")
   if (grepl("^centimet(er|re)s?$", text)) return("centimeter")
   if (grepl("^met(er|re)s?$", text)) return("meter")
@@ -1756,7 +1759,25 @@ validate_salmon_datapackage <- function(path, require_iris = FALSE) {
   text
 }
 
-.ms_measurement_suggestion_is_compatible <- function(suggestion, dict_row) {
+.ms_measurement_has_paired_unit_column <- function(dict_row, dict) {
+  col_name <- .ms_scalar_text(dict_row$column_name)
+  if (!nzchar(col_name) || !grepl("value$", col_name, ignore.case = TRUE)) {
+    return(FALSE)
+  }
+
+  table_matches <- rep(TRUE, nrow(dict))
+  for (key in intersect(c("dataset_id", "table_id"), names(dict_row))) {
+    row_value <- .ms_scalar_text(dict_row[[key]])
+    if (nzchar(row_value) && key %in% names(dict)) {
+      table_matches <- table_matches & !is.na(dict[[key]]) & as.character(dict[[key]]) == row_value
+    }
+  }
+
+  sibling_name <- paste0(sub("value$", "", col_name, ignore.case = TRUE), "unit")
+  any(table_matches & !is.na(dict$column_name) & tolower(as.character(dict$column_name)) == tolower(sibling_name))
+}
+
+.ms_measurement_suggestion_is_compatible <- function(suggestion, dict_row, dict = NULL) {
   role <- tolower(as.character(dict_row$column_role[[1]] %||% ""))
   if (!identical(role, "measurement")) {
     return(TRUE)
@@ -1768,6 +1789,16 @@ validate_salmon_datapackage <- function(path, require_iris = FALSE) {
     if ("column_label" %in% names(suggestion)) .ms_scalar_text(suggestion$column_label) else "",
     if ("column_name" %in% names(suggestion)) .ms_scalar_text(suggestion$column_name) else ""
   )
+
+  target_field <- if ("target_sdp_field" %in% names(suggestion)) {
+    .ms_scalar_text(suggestion$target_sdp_field)
+  } else {
+    ""
+  }
+  if (!is.null(dict) && !identical(target_field, "unit_iri") && .ms_measurement_has_paired_unit_column(dict_row, dict)) {
+    return(FALSE)
+  }
+
   if (!.ms_measurement_query_looks_physical(query_text)) {
     return(TRUE)
   }
@@ -1804,6 +1835,15 @@ validate_salmon_datapackage <- function(path, require_iris = FALSE) {
       }
     }
     return(TRUE)
+  }
+
+  suggestion_iri <- tolower(.ms_scalar_text(suggestion$iri))
+  suggestion_ontology <- tolower(.ms_scalar_text(suggestion$ontology))
+  suggestion_source <- tolower(.ms_scalar_text(suggestion$source))
+  if (grepl("rs\\.tdwg\\.org/dwc/terms/", suggestion_iri) ||
+      suggestion_ontology %in% c("dwc", "darwin core") ||
+      suggestion_source %in% c("dwc", "tdwg")) {
+    return(FALSE)
   }
 
   if (nzchar(match_type) && !grepl("label|unit", match_type)) {
@@ -1864,7 +1904,7 @@ validate_salmon_datapackage <- function(path, require_iris = FALSE) {
         return(FALSE)
       }
       if (identical(role, "measurement")) {
-        return(.ms_measurement_suggestion_is_compatible(suggestion, dict_row))
+        return(.ms_measurement_suggestion_is_compatible(suggestion, dict_row, dict = dict))
       }
       .ms_non_measurement_suggestion_is_compatible(suggestion, dict_row)
     }, logical(1)))

--- a/R/semantics-helpers.R
+++ b/R/semantics-helpers.R
@@ -163,9 +163,15 @@ suggest_semantics <- function(df,
     values <- values[!vapply(values, is_missing, logical(1))]
     if (length(values) == 0) "" else values[[1]]
   }
+  decamelize_text <- function(x) {
+    x <- as.character(x %||% "")
+    x[is.na(x)] <- ""
+    gsub("([a-z0-9])([A-Z])", "\\1 \\2", x, perl = TRUE)
+  }
   clean_query <- function(x) {
     x <- as.character(x %||% "")
     x[is.na(x)] <- ""
+    x <- decamelize_text(x)
     x <- gsub("[._]+", " ", x)
     x <- gsub("\\s+", " ", x)
     trimws(x)
@@ -207,6 +213,7 @@ suggest_semantics <- function(df,
   normalize_measurement_unit_query <- function(x) {
     text <- tolower(as.character(x %||% ""))
     text[is.na(text)] <- ""
+    text <- decamelize_text(text)
     text <- gsub("â", "", text, fixed = TRUE)
     text <- gsub("°", " degree ", text, fixed = TRUE)
     text <- gsub("³", "3", text, fixed = TRUE)
@@ -218,6 +225,7 @@ suggest_semantics <- function(df,
     if (grepl("\\b(degree\\s*c|deg\\s*c|celsius)\\b", text)) return("degree celsius")
     if (grepl("^(cms|cumec|cumecs|m3/s|m\\^3/s|m3 s)$", text)) return("cubic meter per second")
     if (grepl("^(km/h|km h|kph)$", text)) return("kilometer per hour")
+    if (grepl("^(square\\s+met(er|re)s?|sq\\s*m|m2)$", text)) return("square meter")
     if (grepl("^(mm|millimet(er|re)s?)$", text)) return("millimeter")
     if (grepl("^(cm|centimet(er|re)s?)$", text)) return("centimeter")
     if (grepl("^(m|met(er|re)s?)$", text)) return("meter")
@@ -250,9 +258,48 @@ suggest_semantics <- function(df,
       if (nzchar(normalized_full_text)) {
         return(normalized_full_text)
       }
+
+      suffix_text <- tolower(clean_query(gsub("\\([^)]*\\)", " ", text)))
+      suffix_match <- regmatches(
+        suffix_text,
+        regexpr("\\bin\\s+(square\\s+met(?:er|re)s?|met(?:er|re)s?|centimet(?:er|re)s?|millimet(?:er|re)s?|degree\\s+celsius|celsius|kilomet(?:er|re)\\s+per\\s+hour|km/h|cms|cumecs|m3/s)\\b", suffix_text, perl = TRUE)
+      )
+      if (length(suffix_match) == 1 && nzchar(suffix_match)) {
+        normalized <- normalize_measurement_unit_query(sub("^in\\s+", "", suffix_match))
+        if (nzchar(normalized)) {
+          return(normalized)
+        }
+      }
     }
 
     ""
+  }
+  paired_unit_query_from_data <- function(row) {
+    column_name <- as.character(row$column_name[[1]] %||% "")
+    if (!nzchar(column_name) || !grepl("value$", column_name, ignore.case = TRUE)) {
+      return("")
+    }
+
+    stem <- sub("value$", "", column_name, ignore.case = TRUE)
+    sibling_hits <- names(df)[tolower(names(df)) == paste0(tolower(stem), "unit")]
+    if (length(sibling_hits) == 0) {
+      return("")
+    }
+
+    sibling_values <- as.character(df[[sibling_hits[[1]]]])
+    sibling_values <- trimws(sibling_values[!is.na(sibling_values)])
+    sibling_values <- sibling_values[nzchar(sibling_values)]
+    if (length(sibling_values) == 0) {
+      return("")
+    }
+
+    sibling_values <- sort(table(sibling_values), decreasing = TRUE)
+    normalized <- normalize_measurement_unit_query(names(sibling_values)[[1]])
+    if (!nzchar(normalized)) {
+      return("")
+    }
+
+    normalized
   }
   normalize_measurement_header_query <- function(x) {
     text <- clean_query(x)
@@ -263,6 +310,7 @@ suggest_semantics <- function(df,
       text <- strsplit(text, "\\s/\\s", perl = TRUE)[[1]][1]
     }
     text <- tolower(clean_query(text))
+    text <- gsub("\\bin\\s+(square\\s+met(?:er|re)s?|met(?:er|re)s?|centimet(?:er|re)s?|millimet(?:er|re)s?|degree\\s+celsius|celsius|kilomet(?:er|re)\\s+per\\s+hour|km/h|cms|cumecs|m3/s)\\b", " ", text, perl = TRUE)
     replacements <- c(
       "\\btemp\\b" = "temperature",
       "\\bspd\\b" = "speed",
@@ -323,6 +371,9 @@ suggest_semantics <- function(df,
       unit_query <- strip_review_placeholder(row$unit_label[[1]])
       if (!nzchar(unit_query)) {
         unit_query <- extract_measurement_header_unit(row$column_label[[1]], row$column_name[[1]])
+      }
+      if (!nzchar(unit_query)) {
+        unit_query <- paired_unit_query_from_data(row)
       }
       if (nzchar(unit_query)) {
         return(unit_query)

--- a/tests/testthat/test-dictionary-helpers.R
+++ b/tests/testthat/test-dictionary-helpers.R
@@ -107,6 +107,22 @@ test_that("infer_dictionary promotes explicit sample-size and partition-size cou
   expect_equal(dict$column_role[dict$column_name == "sample_date"], "temporal")
 })
 
+test_that("infer_dictionary promotes paired value/unit numeric columns into measurement role", {
+  df <- tibble::tibble(
+    sampleSizeValue = c(2046.33, 131340.85),
+    sampleSizeUnit = c("square metre", "square metre"),
+    eventType = c("deployment", "deployment"),
+    commentValue = c("alpha", "beta"),
+    commentUnit = c("note", "note")
+  )
+
+  dict <- infer_dictionary(df, dataset_id = "test-1", table_id = "table-1")
+
+  expect_equal(dict$column_role[dict$column_name == "sampleSizeValue"], "measurement")
+  expect_equal(dict$column_role[dict$column_name == "sampleSizeUnit"], "attribute")
+  expect_equal(dict$column_role[dict$column_name == "commentValue"], "attribute")
+})
+
 test_that("infer_dictionary recognizes wide numeric and percent metrics without promoting QA or reference fields", {
   df <- tibble::tibble(
     `Facility Reference Number` = c(1001, 1002),

--- a/tests/testthat/test-package-helpers.R
+++ b/tests/testthat/test-package-helpers.R
@@ -546,6 +546,189 @@ test_that("create_sdp keeps broad physical measurement matches review-only but s
   expect_equal(count_row$property_iri[[1]], "http://purl.obolibrary.org/obo/STATO_0000047")
 })
 
+test_that("create_sdp keeps camelCase physical DwC property suggestions review-only but still applies unit hits", {
+  resources <- list(
+    event = tibble::tibble(
+      minimumDepthInMeters = c(12.4, 15.1)
+    )
+  )
+
+  fake_find_terms <- function(query, role = NA_character_, sources = c("smn", "gcdfo", "ols", "nvs"), ...) {
+    query <- tolower(query)
+
+    if (identical(role, "unit") && identical(query, "meter")) {
+      return(tibble::tibble(
+        label = "Meter",
+        iri = "http://qudt.org/vocab/unit/M",
+        source = "qudt",
+        ontology = "qudt",
+        role = "unit",
+        match_type = "label_exact",
+        definition = "Length unit",
+        score = 4.5
+      ))
+    }
+
+    if (identical(role, "variable") && grepl("minimum depth", query, fixed = TRUE)) {
+      return(tibble::tibble(
+        label = "Minimum Depth In Meters",
+        iri = "http://rs.tdwg.org/dwc/terms/minimumDepthInMeters",
+        source = "ols",
+        ontology = "dwc",
+        role = "variable",
+        match_type = "dataProperty",
+        definition = "Darwin Core publication property",
+        score = 2.5
+      ))
+    }
+
+    if (identical(role, "property") && grepl("minimum depth", query, fixed = TRUE)) {
+      return(tibble::tibble(
+        label = "Total length measurement",
+        iri = "https://w3id.org/smn/TotalLengthMeasurement",
+        source = "smn",
+        ontology = "smn",
+        role = "property",
+        match_type = "class",
+        definition = "Wrong fish-length property candidate",
+        score = 6.8
+      ))
+    }
+
+    if (identical(role, "entity") && grepl("minimum depth", query, fixed = TRUE)) {
+      return(tibble::tibble(
+        label = "Minimum Depth In Meters",
+        iri = "http://rs.tdwg.org/dwc/terms/minimumDepthInMeters",
+        source = "ols",
+        ontology = "dwc",
+        role = "entity",
+        match_type = "dataProperty",
+        definition = "Darwin Core publication property",
+        score = 2.5
+      ))
+    }
+
+    if (identical(role, "method") && grepl("minimum depth", query, fixed = TRUE)) {
+      return(tibble::tibble(
+        label = "Enumeration method",
+        iri = "https://w3id.org/smn/EnumerationMethod",
+        source = "smn",
+        ontology = "smn",
+        role = "method",
+        match_type = "class",
+        definition = "Generic method class",
+        score = 6.1
+      ))
+    }
+
+    tibble::tibble()
+  }
+
+  pkg_path <- with_mocked_bindings(
+    find_terms = fake_find_terms,
+    {
+      create_sdp(
+        resources,
+        path = file.path(withr::local_tempdir(), "dwc-camel-guard"),
+        dataset_id = "dwc-depth-demo",
+        seed_semantics = TRUE,
+        seed_verbose = FALSE,
+        check_updates = FALSE,
+        overwrite = TRUE
+      )
+    }
+  )
+
+  dict_written <- readr::read_csv(file.path(pkg_path, "metadata", "column_dictionary.csv"), show_col_types = FALSE)
+  depth_row <- dict_written[dict_written$column_name == "minimumDepthInMeters", , drop = FALSE]
+
+  expect_equal(depth_row$column_role[[1]], "measurement")
+  expect_true(is.na(depth_row$term_iri[[1]]) || depth_row$term_iri[[1]] == "")
+  expect_true(is.na(depth_row$property_iri[[1]]) || depth_row$property_iri[[1]] == "")
+  expect_true(is.na(depth_row$entity_iri[[1]]) || depth_row$entity_iri[[1]] == "")
+  expect_true(is.na(depth_row$method_iri[[1]]) || depth_row$method_iri[[1]] == "")
+  expect_equal(depth_row$unit_iri[[1]], "http://qudt.org/vocab/unit/M")
+})
+
+test_that("create_sdp paired value/unit measurements auto-apply only the unit hit", {
+  resources <- list(
+    event = tibble::tibble(
+      sampleSizeValue = c(2046.33, 131340.85),
+      sampleSizeUnit = c("square metre", "square metre"),
+      eventType = c("deployment", "deployment")
+    )
+  )
+
+  fake_find_terms <- function(query, role = NA_character_, sources = c("smn", "gcdfo", "ols", "nvs"), ...) {
+    query <- tolower(query)
+
+    if (identical(role, "unit") && identical(query, "square meter")) {
+      return(tibble::tibble(
+        label = "Square Meter",
+        iri = "http://qudt.org/vocab/unit/M2",
+        source = "qudt",
+        ontology = "qudt",
+        role = "unit",
+        match_type = "label_exact",
+        definition = "Area unit",
+        score = 4.8
+      ))
+    }
+
+    if (identical(role, "variable") && grepl("sample size", query, fixed = TRUE)) {
+      return(tibble::tibble(
+        label = "Sample size",
+        iri = "http://example.org/sample-size",
+        source = "ols",
+        ontology = "demo",
+        role = "variable",
+        match_type = "label_exact",
+        definition = "Still too generic to auto-apply safely here",
+        score = 3.2
+      ))
+    }
+
+    if (identical(role, "property") && grepl("sample size", query, fixed = TRUE)) {
+      return(tibble::tibble(
+        label = "collection size",
+        iri = "http://example.org/collection-size",
+        source = "ols",
+        ontology = "demo",
+        role = "property",
+        match_type = "label_exact",
+        definition = "Generic size property",
+        score = 3.2
+      ))
+    }
+
+    tibble::tibble()
+  }
+
+  pkg_path <- with_mocked_bindings(
+    find_terms = fake_find_terms,
+    {
+      create_sdp(
+        resources,
+        path = file.path(withr::local_tempdir(), "paired-value-unit"),
+        dataset_id = "paired-value-demo",
+        seed_semantics = TRUE,
+        seed_verbose = FALSE,
+        check_updates = FALSE,
+        overwrite = TRUE
+      )
+    }
+  )
+
+  dict_written <- readr::read_csv(file.path(pkg_path, "metadata", "column_dictionary.csv"), show_col_types = FALSE)
+  sample_row <- dict_written[dict_written$column_name == "sampleSizeValue", , drop = FALSE]
+
+  expect_equal(sample_row$column_role[[1]], "measurement")
+  expect_true(is.na(sample_row$term_iri[[1]]) || sample_row$term_iri[[1]] == "")
+  expect_true(is.na(sample_row$property_iri[[1]]) || sample_row$property_iri[[1]] == "")
+  expect_true(is.na(sample_row$entity_iri[[1]]) || sample_row$entity_iri[[1]] == "")
+  expect_equal(sample_row$unit_iri[[1]], "http://qudt.org/vocab/unit/M2")
+})
+
 test_that("create_sdp unit seeding can use role-augmented unit sources", {
   resources <- list(
     hydro = tibble::tibble(


### PR DESCRIPTION
## Summary
- promote paired numeric `*Value` + `*Unit` columns into the measurement path
- recover unit cues from camelCase physical headers like `minimumDepthInMeters`
- keep DwC publication-property suggestions and other non-unit physical auto-fills review-only

## Verification
- `Rscript /tmp/focused_dwc_guard_check.R`
- `Rscript -e "devtools::test()"`
- `Rscript /tmp/real_dwc_guard_replay.R`
