### PR TITLE
fix: prefer canonical SMN W3ID endpoints

### DIFF
--- a/R/ontology_fetch.R
+++ b/R/ontology_fetch.R
@@ -17,8 +17,7 @@ fetch_salmon_ontology <- function(
     cache_dir = file.path(tools::R_user_dir("metasalmon", which = "cache"), "ontology"),
     timeout_seconds = 30,
     fallback_urls = c(
-      "https://w3id.org/smn",
-      "https://dfo-pacific-science.github.io/salmon-domain-ontology/smn.ttl"
+      "https://w3id.org/smn"
     )) {
 
   dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)

--- a/R/term_search_smn.R
+++ b/R/term_search_smn.R
@@ -1,12 +1,12 @@
 # Helpers for Salmon Domain Ontology (SMN) module indexing
 #
-# The shared SMN landing URL (`https://w3id.org/smn/`) currently resolves to a
-# modular Turtle scaffold that imports module files rather than a single
-# RDF/XML term graph. For search, we index the canonical module TTL files from
-# the public salmon-domain-ontology repository as a lightweight lexical index.
+# The shared SMN root (`https://w3id.org/smn/`) is the canonical entrypoint for
+# the latest ontology. For lightweight lexical search we index the canonical
+# module IRIs under `https://w3id.org/smn/modules/...`, which currently remain
+# Turtle-first on W3ID.
 
 .smn_module_urls <- function() {
-  base <- "https://raw.githubusercontent.com/salmon-data-mobilization/salmon-domain-ontology/main/ontology/modules"
+  base <- "https://w3id.org/smn/modules"
   c(
     paste0(base, "/01-entity-systematics.ttl"),
     paste0(base, "/02-observation-measurement.ttl"),

--- a/docs/reference/fetch_salmon_ontology.html
+++ b/docs/reference/fetch_salmon_ontology.html
@@ -9,7 +9,7 @@ the response using ETag / Last-Modified headers when available."><meta property=
 
     <a class="navbar-brand me-2" href="../index.html">metasalmon</a>
 
-    <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">0.0.22</small>
+    <small class="nav-text text-muted me-auto" data-bs-toggle="tooltip" data-bs-placement="bottom" title="">0.0.23</small>
 
 
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
@@ -55,8 +55,7 @@ the response using ETag / Last-Modified headers when available.</p>
 <span>  accept <span class="op">=</span> <span class="st">"text/turtle, application/rdf+xml;q=0.8"</span>,</span>
 <span>  cache_dir <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/file.path.html" class="external-link">file.path</a></span><span class="op">(</span><span class="fu">tools</span><span class="fu">::</span><span class="fu"><a href="https://rdrr.io/r/tools/userdir.html" class="external-link">R_user_dir</a></span><span class="op">(</span><span class="st">"metasalmon"</span>, which <span class="op">=</span> <span class="st">"cache"</span><span class="op">)</span>, <span class="st">"ontology"</span><span class="op">)</span>,</span>
 <span>  timeout_seconds <span class="op">=</span> <span class="fl">30</span>,</span>
-<span>  fallback_urls <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html" class="external-link">c</a></span><span class="op">(</span><span class="st">"https://w3id.org/smn"</span>,</span>
-<span>    <span class="st">"https://dfo-pacific-science.github.io/salmon-domain-ontology/smn.ttl"</span><span class="op">)</span></span>
+<span>  fallback_urls <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html" class="external-link">c</a></span><span class="op">(</span><span class="st">"https://w3id.org/smn"</span><span class="op">)</span></span>
 <span><span class="op">)</span></span></code></pre></div>
     </div>
 

--- a/docs/reference/fetch_salmon_ontology.md
+++ b/docs/reference/fetch_salmon_ontology.md
@@ -11,8 +11,7 @@ fetch_salmon_ontology(
   accept = "text/turtle, application/rdf+xml;q=0.8",
   cache_dir = file.path(tools::R_user_dir("metasalmon", which = "cache"), "ontology"),
   timeout_seconds = 30,
-  fallback_urls = c("https://w3id.org/smn",
-    "https://dfo-pacific-science.github.io/salmon-domain-ontology/smn.ttl")
+  fallback_urls = c("https://w3id.org/smn")
 )
 ```
 

--- a/man/fetch_salmon_ontology.Rd
+++ b/man/fetch_salmon_ontology.Rd
@@ -9,8 +9,7 @@ fetch_salmon_ontology(
   accept = "text/turtle, application/rdf+xml;q=0.8",
   cache_dir = file.path(tools::R_user_dir("metasalmon", which = "cache"), "ontology"),
   timeout_seconds = 30,
-  fallback_urls = c("https://w3id.org/smn",
-    "https://dfo-pacific-science.github.io/salmon-domain-ontology/smn.ttl")
+  fallback_urls = c("https://w3id.org/smn")
 )
 }
 \arguments{


### PR DESCRIPTION
## Summary
- switch SMN module indexing from raw GitHub module URLs to canonical `https://w3id.org/smn/modules/...` IRIs
- remove the legacy direct GitHub Pages fallback for `fetch_salmon_ontology()` so the default shared-ontology fetch path stays on canonical W3ID endpoints
- refresh the generated Rd / reference docs to match the new defaults

## Why
Now that `https://w3id.org/smn` has the merged root + SemVer content-negotiation contract, downstream tooling should prefer the canonical W3ID surface instead of hardcoding raw GitHub or old GitHub Pages transport URLs for the shared ontology.

This keeps `metasalmon` aligned with the shared ontology publication contract and avoids bypassing the persistent identifier layer.

## Validation
- `Rscript -e 'devtools::test(filter = "validation-helpers|term-search")'`
  - result: pass (`281`), with existing warning-only online timeout / validation-warning expectations
