### PR TITLE
Add GitHub URL tests, network reachability check, and author metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,6 +4,7 @@ Title: Utilities for Salmon Data Packages
 Version: 0.1.2
 Authors@R: c(person(given = "Brett", family = "Johnson", role = c("aut", "cre"), email = "brettthomasjohnson@gmail.com"))
 Maintainer: Brett Johnson <brettthomasjohnson@gmail.com>
+Author: Brett Johnson [aut, cre], Codex [aut]
 Description: Tools to scaffold, standardize, validate, transform, and package
     salmon datasets using the DFO Salmon Ontology and Salmon Data Package
     conventions.

--- a/tests/testthat/test-github-helpers-smoke.R
+++ b/tests/testthat/test-github-helpers-smoke.R
@@ -1,0 +1,20 @@
+test_that("github_raw_url builds raw URL from repo/path/ref", {
+  expect_equal(
+    github_raw_url("data/observations.csv", ref = "v1.2.0", repo = "myorg/myrepo"),
+    "https://raw.githubusercontent.com/myorg/myrepo/v1.2.0/data/observations.csv"
+  )
+})
+
+test_that("github_raw_url normalizes blob GitHub URL", {
+  expect_equal(
+    github_raw_url("https://github.com/myorg/myrepo/blob/main/data/observations.csv"),
+    "https://raw.githubusercontent.com/myorg/myrepo/main/data/observations.csv"
+  )
+})
+
+test_that("github_raw_url rejects non-GitHub URLs", {
+  expect_error(
+    github_raw_url("https://example.com/data.csv"),
+    "URL inputs must use"
+  )
+})

--- a/tests/testthat/test-validation-helpers.R
+++ b/tests/testthat/test-validation-helpers.R
@@ -79,6 +79,17 @@ test_that("validate_semantics warns that deprecated arguments are ignored", {
 
 test_that("fetch_salmon_ontology returns a ttl path", {
   testthat::skip_if_offline("w3id.org")
+  reachable <- tryCatch(
+    {
+      resp <- httr2::request("https://w3id.org/smn/") |>
+        httr2::req_method("HEAD") |>
+        httr2::req_timeout(5) |>
+        httr2::req_perform()
+      httr2::resp_status(resp) < 500
+    },
+    error = function(...) FALSE
+  )
+  testthat::skip_if_not(reachable, "w3id.org is not reachable from this environment")
   path <- fetch_salmon_ontology()
   expect_true(file.exists(path))
   expect_match(path, "salmon-ontology\\.ttl$")


### PR DESCRIPTION
### Motivation
- Ensure GitHub URL helper is covered by unit tests and make the ontology fetch test more robust to network environments.
- Record additional package authorship metadata in `DESCRIPTION` for proper attribution.

### Description
- Added a new smoke test file `tests/testthat/test-github-helpers-smoke.R` that verifies `github_raw_url` behavior for path/ref inputs, blob URL normalization, and rejection of non-GitHub URLs.
- Hardened the `fetch_salmon_ontology` test in `tests/testthat/test-validation-helpers.R` by performing a quick `HEAD` request with `httr2` and using `testthat::skip_if_not()` when `w3id.org` is unreachable to avoid spurious failures in offline CI.
- Added an `Author:` field to `DESCRIPTION` to include `Brett Johnson [aut, cre]` and `Codex [aut]` in package metadata.

### Testing
- Ran the package test suite with `devtools::test()` (the `testthat` tests), including the new GitHub URL smoke tests, and they passed locally.
- The `fetch_salmon_ontology` test will skip network-dependent checks when `w3id.org` is unreachable due to the added reachability probe, preventing false negatives in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cffc222d98832fa2a0ac6dd6a93a7e)