### PR TITLE
Fallback to deterministic semantics when LLM review fails

### DIFF
--- a/R/llm-semantic-helpers.R
+++ b/R/llm-semantic-helpers.R
@@ -1547,27 +1547,56 @@
   validated
 }
 
-.ms_llm_abort_if_provider_wide_failure <- function(assessments, config) {
+.ms_has_usable_semantic_suggestions <- function(suggestions) {
+  suggestions <- tibble::as_tibble(suggestions)
+  if (nrow(suggestions) == 0 || !"iri" %in% names(suggestions)) {
+    return(FALSE)
+  }
+
+  iris <- as.character(suggestions$iri)
+  iris[is.na(iris)] <- ""
+  any(nzchar(trimws(iris)))
+}
+
+.ms_llm_abort_if_provider_wide_failure <- function(assessments,
+                                                   config,
+                                                   deterministic_suggestions = NULL) {
   assessments <- tibble::as_tibble(assessments)
   if (nrow(assessments) == 0 || !"llm_error" %in% names(assessments)) {
-    return(invisible(NULL))
+    return(FALSE)
   }
 
   has_error <- !is.na(assessments$llm_error) & nzchar(assessments$llm_error)
   has_decision <- "llm_decision" %in% names(assessments) &
     !is.na(assessments$llm_decision) & nzchar(assessments$llm_decision)
   if (!all(has_error) || any(has_decision)) {
-    return(invisible(NULL))
+    return(FALSE)
   }
 
   model_ref <- paste0(config$provider, "/", config$model)
   unique_errors <- unique(trimws(as.character(assessments$llm_error[has_error])))
   error_summary <- paste(unique_errors[nzchar(unique_errors)], collapse = " | ")
-  cli::cli_abort(c(
+
+  if (.ms_has_usable_semantic_suggestions(deterministic_suggestions)) {
+    warn_lines <- c(
+      "All LLM assessments failed for {.code {model_ref}}; falling back to deterministic semantic suggestions only.",
+      "i" = paste0(nrow(assessments), " target(s) returned only LLM errors, so metasalmon will keep the retrieved semantic suggestions and skip LLM review for this run.")
+    )
+    if (nzchar(error_summary)) {
+      warn_lines <- c(warn_lines, "i" = error_summary)
+    }
+    cli::cli_warn(warn_lines)
+    return(TRUE)
+  }
+
+  abort_lines <- c(
     "All LLM assessments failed for {.code {model_ref}}.",
-    "i" = paste0(nrow(assessments), " target(s) returned only LLM errors, so the package is stopping instead of silently writing review-ready metadata with no usable LLM decisions."),
-    "i" = error_summary
-  ))
+    "i" = paste0(nrow(assessments), " target(s) returned only LLM errors and no usable deterministic semantic suggestions were available.")
+  )
+  if (nzchar(error_summary)) {
+    abort_lines <- c(abort_lines, "i" = error_summary)
+  }
+  cli::cli_abort(abort_lines)
 }
 
 .ms_assess_semantic_suggestions_llm <- function(suggestions,
@@ -1656,7 +1685,20 @@
 
   final_records <- purrr::map(explored, "record")
   assessments <- dplyr::bind_rows(purrr::map(explored, "assessment"))
-  .ms_llm_abort_if_provider_wide_failure(assessments, config)
+  fallback_to_deterministic <- .ms_llm_abort_if_provider_wide_failure(
+    assessments,
+    config,
+    deterministic_suggestions = suggestions
+  )
+  if (isTRUE(fallback_to_deterministic)) {
+    suggestions <- suggestions |>
+      dplyr::select(-dplyr::any_of(c(".ms_group_key", ".ms_bundle_key", ".ms_row_order")))
+    return(list(
+      suggestions = suggestions,
+      assessments = assessments
+    ))
+  }
+
   suggestions <- dplyr::bind_rows(purrr::map(final_records, "group"))
   suggestions$.ms_group_key <- .ms_llm_group_key_df(suggestions)
   suggestions$.ms_row_order <- seq_len(nrow(suggestions))

--- a/tests/testthat/test-dictionary-helpers.R
+++ b/tests/testthat/test-dictionary-helpers.R
@@ -194,6 +194,63 @@ test_that("infer_dictionary can seed semantic suggestions", {
   )
 })
 
+test_that("infer_dictionary falls back to deterministic suggestions when LLM assessment fails", {
+  fake_search <- function(query, role, sources) {
+    tibble::tibble(
+      label = c(paste(role, "best"), paste(role, "alt")),
+      iri = c(
+        paste0("https://example.org/", role, "/best"),
+        paste0("https://example.org/", role, "/alt")
+      ),
+      source = c("smn", "smn"),
+      ontology = c("demo", "demo"),
+      role = c(role, role),
+      match_type = c("label_partial", "label_partial"),
+      definition = c("Best match from retrieved shortlist", "Alternative match from retrieved shortlist"),
+      score = c(0.9, 0.5)
+    )
+  }
+
+  failing_request <- function(messages, config) {
+    stop("HTTP 402 Payment Required.")
+  }
+
+  dict <- with_mocked_bindings(
+    find_terms = fake_search,
+    {
+      out <- NULL
+      expect_warning(
+        out <- infer_dictionary(
+          data.frame(count = c(1L, 2L), species = c("Coho", "Chinook")),
+          dataset_id = "dataset-1",
+          table_id = "table-1",
+          seed_semantics = TRUE,
+          semantic_sources = "smn",
+          semantic_max_per_role = 2,
+          seed_verbose = FALSE,
+          llm_assess = TRUE,
+          llm_provider = "openrouter",
+          llm_model = "openai/gpt-5.4-mini",
+          llm_api_key = "dummy-key",
+          llm_top_n = 2,
+          llm_request_fn = failing_request
+        ),
+        "falling back to deterministic semantic suggestions only"
+      )
+      out
+    }
+  )
+
+  suggestions <- attr(dict, "semantic_suggestions")
+  assessments <- attr(dict, "semantic_llm_assessments")
+
+  expect_s3_class(dict, "tbl_df")
+  expect_gt(nrow(suggestions), 0)
+  expect_false(any(startsWith(names(suggestions), "llm_")))
+  expect_true(any(suggestions$iri == "https://example.org/variable/best"))
+  expect_true(all(!is.na(assessments$llm_error) & nzchar(assessments$llm_error)))
+})
+
 test_that("infer_dictionary accepts named resource lists and can seed metadata-aware suggestions", {
   resources <- list(
     catches = data.frame(

--- a/tests/testthat/test-llm-semantic-helpers.R
+++ b/tests/testthat/test-llm-semantic-helpers.R
@@ -149,7 +149,7 @@ test_that("suggest_semantics accepts arbitrary OpenRouter model IDs", {
   expect_true(all(assessments$llm_model == "openai/gpt-5.4-mini"))
 })
 
-test_that("suggest_semantics aborts when every LLM assessment fails", {
+test_that("suggest_semantics falls back to deterministic suggestions when every LLM assessment fails", {
   dict <- tibble::tibble(
     dataset_id = "d1",
     table_id = "t1",
@@ -187,23 +187,47 @@ test_that("suggest_semantics aborts when every LLM assessment fails", {
     stop("HTTP 402 Payment Required.")
   }
 
-  suppressWarnings(
-    expect_error(
-      suggest_semantics(
-        NULL,
-        dict,
-        sources = "smn",
-        max_per_role = 2,
-        search_fn = fake_search,
-        llm_assess = TRUE,
-        llm_provider = "openrouter",
-        llm_model = "openai/gpt-5.4-mini",
-        llm_api_key = "dummy-key",
-        llm_top_n = 2,
-        llm_request_fn = failing_request
-      ),
-      "All LLM assessments failed"
-    )
+  res <- NULL
+  expect_warning(
+    res <- suggest_semantics(
+      NULL,
+      dict,
+      sources = "smn",
+      max_per_role = 2,
+      search_fn = fake_search,
+      llm_assess = TRUE,
+      llm_provider = "openrouter",
+      llm_model = "openai/gpt-5.4-mini",
+      llm_api_key = "dummy-key",
+      llm_top_n = 2,
+      llm_request_fn = failing_request
+    ),
+    "falling back to deterministic semantic suggestions only"
+  )
+
+  suggestions <- attr(res, "semantic_suggestions")
+  assessments <- attr(res, "semantic_llm_assessments")
+
+  expect_gt(nrow(suggestions), 0)
+  expect_false(any(startsWith(names(suggestions), "llm_")))
+  expect_true(all(assessments$llm_provider == "openrouter"))
+  expect_true(all(assessments$llm_model == "openai/gpt-5.4-mini"))
+  expect_true(all(!is.na(assessments$llm_error) & nzchar(assessments$llm_error)))
+})
+
+test_that("provider-wide LLM failure still aborts without usable deterministic suggestions", {
+  assessments <- tibble::tibble(
+    llm_error = c("HTTP 429 Too Many Requests.", "HTTP 402 Payment Required."),
+    llm_decision = c(NA_character_, NA_character_)
+  )
+
+  expect_error(
+    .ms_llm_abort_if_provider_wide_failure(
+      assessments = assessments,
+      config = list(provider = "openrouter", model = "openrouter/free"),
+      deterministic_suggestions = tibble::tibble(iri = c(NA_character_, ""))
+    ),
+    "no usable deterministic semantic suggestions were available"
   )
 })
 

--- a/tests/testthat/test-package-helpers.R
+++ b/tests/testthat/test-package-helpers.R
@@ -132,6 +132,71 @@ test_that("create_sdp creates valid package", {
   expect_true(file.exists(file.path(pkg_path_with_edh, "metadata", "metadata-edh-hnap.xml")))
 })
 
+test_that("create_sdp falls back to deterministic suggestions when LLM assessment fails", {
+  fake_search <- function(query, role, sources) {
+    tibble::tibble(
+      label = c(paste(role, "best"), paste(role, "alt")),
+      iri = c(
+        paste0("https://example.org/", role, "/best"),
+        paste0("https://example.org/", role, "/alt")
+      ),
+      source = c("smn", "smn"),
+      ontology = c("demo", "demo"),
+      role = c(role, role),
+      match_type = c("label_partial", "label_partial"),
+      definition = c("Best match from retrieved shortlist", "Alternative match from retrieved shortlist"),
+      score = c(0.9, 0.5)
+    )
+  }
+
+  failing_request <- function(messages, config) {
+    stop("HTTP 402 Payment Required.")
+  }
+
+  temp_dir <- withr::local_tempdir()
+  resources <- list(main = tibble::tibble(species = c("Coho", "Chinook"), count = c(1L, 2L)))
+
+  pkg_path <- with_mocked_bindings(
+    find_terms = fake_search,
+    {
+      out <- NULL
+      expect_warning(
+        out <- create_sdp(
+          resources,
+          path = file.path(temp_dir, "package-llm-fallback"),
+          dataset_id = "llm-fallback-demo",
+          seed_semantics = TRUE,
+          semantic_sources = "smn",
+          semantic_max_per_role = 2,
+          seed_verbose = FALSE,
+          llm_assess = TRUE,
+          llm_provider = "openrouter",
+          llm_model = "openai/gpt-5.4-mini",
+          llm_api_key = "dummy-key",
+          llm_top_n = 2,
+          llm_request_fn = failing_request,
+          check_updates = FALSE,
+          overwrite = TRUE
+        ),
+        "falling back to deterministic semantic suggestions only"
+      )
+      out
+    }
+  )
+
+  expect_true(dir.exists(pkg_path))
+  expect_true(file.exists(file.path(pkg_path, "semantic_suggestions.csv")))
+
+  dict <- readr::read_csv(file.path(pkg_path, "metadata", "column_dictionary.csv"), show_col_types = FALSE)
+  suggestions <- readr::read_csv(file.path(pkg_path, "semantic_suggestions.csv"), show_col_types = FALSE)
+  iri_cols <- grep("_iri$", names(dict), value = TRUE)
+  iri_values <- unlist(dict[iri_cols], use.names = FALSE)
+
+  expect_gt(nrow(suggestions), 0)
+  expect_false(any(startsWith(names(suggestions), "llm_")))
+  expect_true(any(grepl("https://example.org/", iri_values, fixed = TRUE), na.rm = TRUE))
+})
+
 test_that("create_sdp auto-enables EDH XML export when legacy edh_profile is supplied", {
   temp_dir <- withr::local_tempdir()
   resources <- list(main = tibble::tibble(species = c("Coho"), count = c(1L)))


### PR DESCRIPTION
## Summary
- fall back to deterministic semantic suggestions when provider-wide LLM review fails but usable deterministic candidates exist
- preserve the hard error when no usable deterministic suggestions are available
- add targeted regression coverage for `suggest_semantics()`, `infer_dictionary()`, and `create_sdp()`

## Why
OpenRouter/OpenAI-compatible failures like `429`, `402`, timeouts, or similar transient/provider-wide errors could abort the entire semantic-seeding workflow even when deterministic retrieval had already produced usable suggestions. This change keeps the review-ready workflow moving in degraded mode instead of dying unnecessarily.

## Testing
```sh
Rscript - <<'RS'
devtools::load_all(quiet = TRUE)
files <- c(
  'tests/testthat/test-llm-semantic-helpers.R',
  'tests/testthat/test-dictionary-helpers.R',
  'tests/testthat/test-package-helpers.R'
)
for (path in files) {
  cat('\n===', path, '===\n')
  testthat::test_file(path, reporter = testthat::SummaryReporter$new())
}
RS
```
