### PR TITLE
Support OpenAI reasoning effort and GPT-5 request defaults

### DIFF
--- a/R/dictionary-helpers.R
+++ b/R/dictionary-helpers.R
@@ -31,6 +31,8 @@
 #'   `suggest_semantics()`.
 #' @param llm_base_url Optional OpenAI-compatible base URL forwarded to
 #'   `suggest_semantics()`.
+#' @param llm_reasoning_effort Optional reasoning-effort hint forwarded to
+#'   `suggest_semantics()` when using the OpenAI provider.
 #' @param llm_top_n Maximum number of retrieved candidates sent to the LLM per
 #'   target.
 #' @param llm_context_files Optional local context files forwarded to
@@ -79,6 +81,7 @@ infer_dictionary <- function(df, guess_types = TRUE, dataset_id = "dataset-1", t
                             llm_model = NULL,
                             llm_api_key = NULL,
                             llm_base_url = NULL,
+                            llm_reasoning_effort = NULL,
                             llm_top_n = 5L,
                             llm_context_files = NULL,
                             llm_context_text = NULL,
@@ -90,6 +93,7 @@ infer_dictionary <- function(df, guess_types = TRUE, dataset_id = "dataset-1", t
     !is.null(llm_model) ||
     !is.null(llm_api_key) ||
     !is.null(llm_base_url) ||
+    !is.null(llm_reasoning_effort) ||
     !is.null(llm_request_fn)
   semantic_seed_max_per_role <- .ms_llm_effective_shortlist_size(
     semantic_max_per_role,
@@ -176,6 +180,7 @@ infer_dictionary <- function(df, guess_types = TRUE, dataset_id = "dataset-1", t
           llm_model = llm_model,
           llm_api_key = llm_api_key,
           llm_base_url = llm_base_url,
+          llm_reasoning_effort = llm_reasoning_effort,
           llm_top_n = llm_top_n,
           llm_context_files = llm_context_files,
           llm_context_text = llm_context_text,
@@ -251,6 +256,7 @@ infer_dictionary <- function(df, guess_types = TRUE, dataset_id = "dataset-1", t
           llm_model = llm_model,
           llm_api_key = llm_api_key,
           llm_base_url = llm_base_url,
+          llm_reasoning_effort = llm_reasoning_effort,
           llm_top_n = llm_top_n,
           llm_context_files = llm_context_files,
           llm_context_text = llm_context_text,
@@ -1197,4 +1203,3 @@ apply_salmon_dictionary <- function(df, dict, codes = NULL, strict = TRUE) {
 
   result
 }
-

--- a/R/llm-semantic-helpers.R
+++ b/R/llm-semantic-helpers.R
@@ -161,7 +161,8 @@
                                    api_key = NULL,
                                    base_url = NULL,
                                    timeout_seconds = 60,
-                                   request_fn = NULL) {
+                                   request_fn = NULL,
+                                   reasoning_effort = NULL) {
   provider <- match.arg(provider)
 
   model <- .ms_llm_non_empty_string(model)
@@ -236,6 +237,14 @@
     )
   }
 
+  reasoning_effort <- .ms_llm_non_empty_string(reasoning_effort)
+  if (is.na(reasoning_effort)) {
+    reasoning_effort <- .ms_llm_non_empty_string(Sys.getenv("METASALMON_LLM_REASONING_EFFORT", unset = ""))
+  }
+  if (!identical(provider, "openai")) {
+    reasoning_effort <- NA_character_
+  }
+
   timeout_seconds <- suppressWarnings(as.numeric(timeout_seconds[[1]] %||% 60))
   if (is.na(timeout_seconds) || timeout_seconds <= 0) {
     cli::cli_abort("{.arg llm_timeout_seconds} must be a positive number.")
@@ -253,7 +262,8 @@
     api_key = api_key,
     base_url = sub("/$", "", base_url),
     timeout_seconds = timeout_seconds,
-    request_fn = request_fn %||% .ms_llm_chat_json_request
+    request_fn = request_fn %||% .ms_llm_chat_json_request,
+    reasoning_effort = reasoning_effort
   )
 }
 
@@ -1249,6 +1259,27 @@
   text
 }
 
+.ms_llm_build_chat_request_body <- function(messages, config) {
+  body <- list(
+    model = config$model,
+    messages = messages
+  )
+
+  provider <- tolower(trimws(as.character(config$provider %||% "")))
+  model <- tolower(trimws(as.character(config$model %||% "")))
+  omit_temperature <- identical(provider, "openai") && grepl("^gpt-5", model)
+
+  if (!omit_temperature) {
+    body$temperature <- 0
+  }
+
+  if (!is.na(config$reasoning_effort %||% NA_character_)) {
+    body$reasoning_effort <- config$reasoning_effort
+  }
+
+  body
+}
+
 .ms_llm_chat_json_request <- function(messages, config) {
   req <- httr2::request(paste0(config$base_url, "/chat/completions")) |>
     httr2::req_method("POST") |>
@@ -1258,11 +1289,7 @@
     ) |>
     httr2::req_user_agent(ms_user_agent()) |>
     httr2::req_timeout(seconds = config$timeout_seconds) |>
-    httr2::req_body_json(list(
-      model = config$model,
-      messages = messages,
-      temperature = 0
-    ), auto_unbox = TRUE)
+    httr2::req_body_json(.ms_llm_build_chat_request_body(messages, config), auto_unbox = TRUE)
 
   if (identical(config$provider, "openrouter")) {
     req <- httr2::req_headers(
@@ -1575,6 +1602,7 @@
                                                 model = NULL,
                                                 api_key = NULL,
                                                 base_url = NULL,
+                                                reasoning_effort = NULL,
                                                 top_n = 5L,
                                                 context_files = NULL,
                                                 context_text = NULL,
@@ -1597,7 +1625,8 @@
     api_key = api_key,
     base_url = base_url,
     timeout_seconds = timeout_seconds,
-    request_fn = request_fn
+    request_fn = request_fn,
+    reasoning_effort = reasoning_effort
   )
   top_n <- .ms_llm_effective_top_n(config, top_n)
   context_chunk_pool <- .ms_collect_context_chunks(

--- a/R/package-helpers.R
+++ b/R/package-helpers.R
@@ -335,6 +335,8 @@ write_salmon_datapackage <- function(
 #'   `suggest_semantics()`.
 #' @param llm_base_url Optional OpenAI-compatible base URL forwarded to
 #'   `suggest_semantics()`.
+#' @param llm_reasoning_effort Optional reasoning-effort hint forwarded to
+#'   `suggest_semantics()` when using the OpenAI provider.
 #' @param llm_top_n Maximum number of retrieved candidates sent to the LLM per
 #'   target.
 #' @param llm_context_files Optional local context files forwarded to
@@ -402,6 +404,7 @@ infer_salmon_datapackage_artifacts <- function(
     llm_model = NULL,
     llm_api_key = NULL,
     llm_base_url = NULL,
+    llm_reasoning_effort = NULL,
     llm_top_n = 5L,
     llm_context_files = NULL,
     llm_context_text = NULL,
@@ -414,6 +417,7 @@ infer_salmon_datapackage_artifacts <- function(
     !is.null(llm_model) ||
     !is.null(llm_api_key) ||
     !is.null(llm_base_url) ||
+    !is.null(llm_reasoning_effort) ||
     !is.null(llm_request_fn)
   if (!isTRUE(seed_semantics) && llm_requested) {
     cli::cli_warn(c(
@@ -511,6 +515,7 @@ infer_salmon_datapackage_artifacts <- function(
         llm_model = llm_model,
         llm_api_key = llm_api_key,
         llm_base_url = llm_base_url,
+        llm_reasoning_effort = llm_reasoning_effort,
         llm_top_n = llm_top_n,
         llm_context_files = llm_context_files,
         llm_context_text = llm_context_text,
@@ -583,6 +588,8 @@ infer_salmon_datapackage_artifacts <- function(
 #'   `suggest_semantics()`.
 #' @param llm_base_url Optional OpenAI-compatible base URL forwarded to
 #'   `suggest_semantics()`.
+#' @param llm_reasoning_effort Optional reasoning-effort hint forwarded to
+#'   `suggest_semantics()` when using the OpenAI provider.
 #' @param llm_top_n Maximum number of retrieved candidates sent to the LLM per
 #'   target.
 #' @param llm_context_files Optional local context files forwarded to
@@ -679,6 +686,7 @@ create_sdp <- function(
     llm_model = NULL,
     llm_api_key = NULL,
     llm_base_url = NULL,
+    llm_reasoning_effort = NULL,
     llm_top_n = 5L,
     llm_context_files = NULL,
     llm_context_text = NULL,
@@ -796,6 +804,7 @@ create_sdp <- function(
     llm_model = llm_model,
     llm_api_key = llm_api_key,
     llm_base_url = llm_base_url,
+    llm_reasoning_effort = llm_reasoning_effort,
     llm_top_n = llm_top_n,
     llm_context_files = llm_context_files,
     llm_context_text = llm_context_text,

--- a/R/semantics-helpers.R
+++ b/R/semantics-helpers.R
@@ -228,6 +228,8 @@
 #'   set via `METASALMON_LLM_BASE_URL`. For `llm_provider = "chapi"`, the
 #'   package defaults to `https://chapi-dev.intra.azure.cloud.dfo-mpo.gc.ca/api`
 #'   and also checks `CHAPI_BASE_URL`.
+#' @param llm_reasoning_effort Optional reasoning-effort hint forwarded to the
+#'   OpenAI chat-completions request body when `llm_provider = "openai"`.
 #' @param llm_top_n Maximum number of retrieved candidates to send to the LLM
 #'   per target for each assessment round. Default is `5`.
 #' @param llm_context_files Optional character vector of local context files
@@ -343,6 +345,7 @@ suggest_semantics <- function(df,
                               llm_model = NULL,
                               llm_api_key = NULL,
                               llm_base_url = NULL,
+                              llm_reasoning_effort = NULL,
                               llm_top_n = 5L,
                               llm_context_files = NULL,
                               llm_context_text = NULL,
@@ -1222,6 +1225,7 @@ suggest_semantics <- function(df,
       model = llm_model,
       api_key = llm_api_key,
       base_url = llm_base_url,
+      reasoning_effort = llm_reasoning_effort,
       top_n = llm_top_n,
       context_files = llm_context_files,
       context_text = llm_context_text,

--- a/tests/testthat/test-llm-semantic-helpers.R
+++ b/tests/testthat/test-llm-semantic-helpers.R
@@ -149,6 +149,94 @@ test_that("suggest_semantics accepts arbitrary OpenRouter model IDs", {
   expect_true(all(assessments$llm_model == "openai/gpt-5.4-mini"))
 })
 
+test_that("suggest_semantics forwards OpenAI reasoning effort to LLM review", {
+  dict <- tibble::tibble(
+    dataset_id = "d1",
+    table_id = "t1",
+    column_name = "spawner_count",
+    column_label = "Spawner count",
+    column_description = "Natural-origin spawner abundance estimate",
+    column_role = "measurement",
+    value_type = "integer",
+    unit_label = NA_character_,
+    unit_iri = NA_character_,
+    term_iri = NA_character_,
+    property_iri = NA_character_,
+    entity_iri = NA_character_,
+    constraint_iri = NA_character_,
+    method_iri = NA_character_
+  )
+
+  fake_search <- function(query, role, sources) {
+    tibble::tibble(
+      label = c(paste(role, "best"), paste(role, "alt")),
+      iri = c(
+        paste0("https://example.org/", role, "/best"),
+        paste0("https://example.org/", role, "/alt")
+      ),
+      source = c("smn", "smn"),
+      ontology = c("demo", "demo"),
+      role = c(role, role),
+      match_type = c("label_partial", "label_partial"),
+      definition = c("Best match from retrieved shortlist", "Alternative match from retrieved shortlist"),
+      score = c(0.9, 0.5)
+    )
+  }
+
+  fake_request <- function(messages, config) {
+    expect_equal(config$provider, "openai")
+    expect_equal(config$model, "gpt-5.4")
+    expect_equal(config$reasoning_effort, "xhigh")
+
+    list(
+      decision = "accept",
+      selected_candidate_index = 1,
+      confidence = 0.95,
+      rationale = "The reasoning-effort value should pass through unchanged.",
+      missing_context = ""
+    )
+  }
+
+  res <- suggest_semantics(
+    NULL,
+    dict,
+    sources = "smn",
+    max_per_role = 2,
+    search_fn = fake_search,
+    llm_assess = TRUE,
+    llm_provider = "openai",
+    llm_model = "gpt-5.4",
+    llm_api_key = "dummy-key",
+    llm_reasoning_effort = "xhigh",
+    llm_top_n = 2,
+    llm_request_fn = fake_request
+  )
+
+  assessments <- attr(res, "semantic_llm_assessments")
+  expect_true(all(assessments$llm_provider == "openai"))
+  expect_true(all(assessments$llm_model == "gpt-5.4"))
+})
+
+test_that("chat request body includes reasoning effort only when configured", {
+  messages <- list(list(role = "user", content = "test"))
+
+  openai_body <- .ms_llm_build_chat_request_body(messages, list(
+    provider = "openai",
+    model = "gpt-5.4",
+    reasoning_effort = "xhigh"
+  ))
+  openrouter_body <- .ms_llm_build_chat_request_body(messages, list(
+    provider = "openrouter",
+    model = "openai/gpt-5.4-mini",
+    reasoning_effort = NA_character_
+  ))
+
+  expect_equal(openai_body$reasoning_effort, "xhigh")
+  expect_false("temperature" %in% names(openai_body))
+  expect_false("reasoning_effort" %in% names(openrouter_body))
+  expect_equal(openrouter_body$temperature, 0)
+})
+
 test_that("suggest_semantics aborts when every LLM assessment fails", {
   dict <- tibble::tibble(
     dataset_id = "d1",


### PR DESCRIPTION
## Summary
- thread `llm_reasoning_effort` through the semantic-review helpers and package builders
- forward `reasoning_effort` in OpenAI chat-completions requests
- omit explicit `temperature` for OpenAI GPT-5 models, which require the default value
- add request-body tests covering reasoning effort and GPT-5 request construction

## Why
A downstream Sockeye International SDP build needed to run `metasalmon` semantic review with `llm_provider = "openai"`, `llm_model = "gpt-5.4"`, and `llm_reasoning_effort = "xhigh"`.

Two gaps showed up during that run:
1. `metasalmon` did not expose a way to pass reasoning effort through to the OpenAI request body.
2. OpenAI GPT-5 chat completions rejected the existing hard-coded `temperature = 0` payload, because those models only accept the default temperature.

This PR fixes both so GPT-5 semantic review works without local patching.

## Validation
- `Rscript -e 'devtools::test("data/intermediate/tooling/metasalmon", filter = "(llm-semantic-helpers|package-helpers)")'`
- downstream 2025 Sockeye International Salmon Data Package build completed successfully with strict validation after installing the patched package
